### PR TITLE
Simplify CLI command names and add normalization logic

### DIFF
--- a/app/app/Console/Commands/BootstrapDemo.php
+++ b/app/app/Console/Commands/BootstrapDemo.php
@@ -8,7 +8,7 @@ use App\Support\DevOpsService;
 
 class BootstrapDemo extends Command
 {
-    protected $signature = 'haasib:bootstrap:demo {--name=Founder} {--email=} {--companies=} {--role=owner}';
+    protected $signature = 'bootstrap:demo {--name=Founder} {--email=} {--companies=} {--role=owner}';
     protected $description = 'Create a user and attach companies list';
 
     public function handle(DevOpsService $ops): int

--- a/app/app/Console/Commands/CompanyAdd.php
+++ b/app/app/Console/Commands/CompanyAdd.php
@@ -8,7 +8,7 @@ use App\Support\DevOpsService;
 
 class CompanyAdd extends Command
 {
-    protected $signature = 'haasib:company:add {--name=}';
+    protected $signature = 'company:add {--name=}';
     protected $description = 'Add company (idempotent by name)';
 
     public function handle(DevOpsService $ops): int

--- a/app/app/Console/Commands/CompanyAssign.php
+++ b/app/app/Console/Commands/CompanyAssign.php
@@ -8,7 +8,7 @@ use App\Support\DevOpsService;
 
 class CompanyAssign extends Command
 {
-    protected $signature = 'haasib:company:assign {--email=} {--company=} {--role=viewer}';
+    protected $signature = 'company:assign {--email=} {--company=} {--role=viewer}';
     protected $description = 'Assign user to company with role';
 
     public function handle(DevOpsService $ops): int

--- a/app/app/Console/Commands/CompanyDelete.php
+++ b/app/app/Console/Commands/CompanyDelete.php
@@ -8,7 +8,7 @@ use App\Support\DevOpsService;
 
 class CompanyDelete extends Command
 {
-    protected $signature = 'haasib:company:delete {--company=}';
+    protected $signature = 'company:delete {--company=}';
     protected $description = 'Delete a company by id or name';
 
     public function handle(DevOpsService $ops): int

--- a/app/app/Console/Commands/CompanyUnassign.php
+++ b/app/app/Console/Commands/CompanyUnassign.php
@@ -8,7 +8,7 @@ use App\Support\DevOpsService;
 
 class CompanyUnassign extends Command
 {
-    protected $signature = 'haasib:company:unassign {--email=} {--company=}';
+    protected $signature = 'company:unassign {--email=} {--company=}';
     protected $description = 'Remove user from company';
 
     public function handle(DevOpsService $ops): int

--- a/app/app/Console/Commands/UserAdd.php
+++ b/app/app/Console/Commands/UserAdd.php
@@ -8,7 +8,7 @@ use App\Support\DevOpsService;
 
 class UserAdd extends Command
 {
-    protected $signature = 'haasib:user:add {--name=} {--email=} {--password=}';
+    protected $signature = 'user:add {--name=} {--email=} {--password=}';
     protected $description = 'Add user (idempotent by email)';
 
     public function handle(DevOpsService $ops): int

--- a/app/app/Console/Commands/UserDelete.php
+++ b/app/app/Console/Commands/UserDelete.php
@@ -8,7 +8,7 @@ use App\Support\DevOpsService;
 
 class UserDelete extends Command
 {
-    protected $signature = 'haasib:user:delete {--email=}';
+    protected $signature = 'user:delete {--email=}';
     protected $description = 'Delete a user by email';
 
     public function handle(DevOpsService $ops): int


### PR DESCRIPTION
## Summary
- remove `haasib:` prefix from console command signatures
- support shorthand `entity action` syntax via controller normalization
- update Dev CLI examples and command mapping

## Testing
- `composer test` *(fails: connection to server at "127.0.0.1", port 5432 failed)*


------
https://chatgpt.com/codex/tasks/task_e_68ad7b700fc88322b1cd899b97a30478