### PR TITLE
Refine DevOps company lookup logic

### DIFF
--- a/app/app/Support/DevOpsService.php
+++ b/app/app/Support/DevOpsService.php
@@ -76,6 +76,14 @@ class DevOpsService
 
     private function findCompany(string $idOrName): Company
     {
-        return Company::where('id', $idOrName)->orWhere('name', $idOrName)->firstOrFail();
+        $idOrName = trim($idOrName);
+
+        if (Str::isUuid($idOrName)) {
+            return Company::findOrFail($idOrName);
+        }
+
+        return Company::where('name', $idOrName)
+            ->orWhere('slug', $idOrName)
+            ->firstOrFail();
     }
 }


### PR DESCRIPTION
## Summary
- Detect UUIDs when looking up companies
- Trim and resolve companies by ID or name/slug

## Testing
- `php artisan test tests/Feature/Console/ArtisanCommandsTest.php` *(fails: connection to server at "127.0.0.1", port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9b5b886c8322a130a005e73d340f