### PR TITLE
Always register Dev CLI routes

### DIFF
--- a/app/routes/web.php
+++ b/app/routes/web.php
@@ -5,12 +5,10 @@ use Illuminate\Foundation\Application;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
 
-if (config('app.dev_console_enabled')) {
-    Route::middleware(['auth','throttle:devcli'])->group(function () {
-        Route::get('/dev/cli', [\App\Http\Controllers\DevCliController::class, 'index'])->name('dev.cli');
-        Route::post('/dev/cli/execute', [\App\Http\Controllers\DevCliController::class, 'execute'])->name('dev.cli.execute');
-    });
-}
+Route::middleware(['auth','throttle:devcli'])->group(function () {
+    Route::get('/dev/cli', [\App\Http\Controllers\DevCliController::class, 'index'])->name('dev.cli');
+    Route::post('/dev/cli/execute', [\App\Http\Controllers\DevCliController::class, 'execute'])->name('dev.cli.execute');
+});
 
 Route::get('/', function () {
     return Inertia::render('Welcome', [


### PR DESCRIPTION
## Summary
- Always register Dev CLI HTTP routes within auth and throttle middleware
- Use controller checks to gate access when dev console is disabled

## Testing
- `php artisan test tests/Feature/DevCliHttpTest.php` *(fails: Test file not found)*
- `php artisan test tests/Feature/Console/DevCliHttpTest.php` *(fails: connection to server at "127.0.0.1", port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9b6828d88322b32da9590225ac64