### PR TITLE
Fix missing Ziggy route helper in client app

### DIFF
--- a/app/resources/js/app.js
+++ b/app/resources/js/app.js
@@ -2,6 +2,7 @@
 import './bootstrap'   // if Breeze created it; harmless if present
 import { createInertiaApp } from '@inertiajs/vue3'
 import { createApp, h } from 'vue'
+import { ZiggyVue } from '../../vendor/tightenco/ziggy'
 
 createInertiaApp({
   resolve: name => {
@@ -11,6 +12,10 @@ createInertiaApp({
   setup({ el, App, props, plugin }) {
     const vue = createApp({ render: () => h(App, props) })
     vue.use(plugin)
+    vue.use(ZiggyVue, {
+      ...props.initialPage.props.ziggy,
+      location: new URL(props.initialPage.props.ziggy.location),
+    })
     vue.mount(el)
   },
 })


### PR DESCRIPTION
## Summary
- register ZiggyVue plugin in app bootstrap to provide global `route()` helper

## Testing
- `npm test` *(fails: Missing script "test")*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adb1f61f0c8322b1f6e73ede5ec588