### PR TITLE
feat: add command palette and DevOps command bus

### DIFF
--- a/app/app/Actions/DevOps/CompanyAssign.php
+++ b/app/app/Actions/DevOps/CompanyAssign.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Actions\DevOps;
+
+use App\Models\Company;
+use App\Models\User;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\DB;
+
+class CompanyAssign
+{
+    public function handle(array $p, User $actor): array
+    {
+        $data = Validator::make($p, [
+            'email' => 'required|email',
+            'company' => 'required|string',
+            'role' => 'required|in:owner,admin,accountant,viewer',
+        ])->validate();
+
+        $company = Company::where('id', $data['company'])
+            ->orWhere('slug', $data['company'])
+            ->orWhere('name', $data['company'])
+            ->firstOrFail();
+
+        if (!$actor->isSuperAdmin()) {
+            $active = session('current_company_id');
+            abort_if($active !== $company->id, 403);
+            $isOwner = $actor->companies()
+                ->where('auth.company_user.company_id', $company->id)
+                ->wherePivot('role', 'owner')
+                ->exists();
+            abort_unless($isOwner, 403);
+        }
+
+        DB::transaction(function () use ($data, $company) {
+            $user = User::where('email', $data['email'])->firstOrFail();
+            $company->users()->syncWithoutDetaching([$user->id => ['role' => $data['role']]]);
+        });
+
+        return ['message' => 'User assigned', 'data' => ['email' => $data['email'], 'company' => $company->slug]];
+    }
+}

--- a/app/app/Actions/DevOps/CompanyCreate.php
+++ b/app/app/Actions/DevOps/CompanyCreate.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Actions\DevOps;
+
+use App\Models\Company;
+use App\Models\User;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\DB;
+
+class CompanyCreate
+{
+    public function handle(array $p, User $actor): array
+    {
+        abort_unless($actor->isSuperAdmin(), 403);
+
+        $data = Validator::make($p, [
+            'name' => 'required|string',
+            'base_currency' => 'nullable|string|size:3',
+            'language' => 'nullable|string',
+            'locale' => 'nullable|string',
+        ])->validate();
+
+        $company = DB::transaction(fn() => Company::create($data));
+
+        return ['message' => 'Company created', 'data' => ['slug' => $company->slug]];
+    }
+}

--- a/app/app/Actions/DevOps/CompanyDelete.php
+++ b/app/app/Actions/DevOps/CompanyDelete.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Actions\DevOps;
+
+use App\Models\Company;
+use App\Models\User;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\DB;
+
+class CompanyDelete
+{
+    public function handle(array $p, User $actor): array
+    {
+        abort_unless($actor->isSuperAdmin(), 403);
+
+        $data = Validator::make($p, [
+            'company' => 'required|string',
+        ])->validate();
+
+        DB::transaction(function () use ($data) {
+            $company = Company::where('id', $data['company'])
+                ->orWhere('slug', $data['company'])
+                ->orWhere('name', $data['company'])
+                ->firstOrFail();
+            $company->delete();
+        });
+
+        return ['message' => 'Company deleted', 'data' => ['company' => $data['company']]];
+    }
+}

--- a/app/app/Actions/DevOps/CompanyUnassign.php
+++ b/app/app/Actions/DevOps/CompanyUnassign.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Actions\DevOps;
+
+use App\Models\Company;
+use App\Models\User;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\DB;
+
+class CompanyUnassign
+{
+    public function handle(array $p, User $actor): array
+    {
+        $data = Validator::make($p, [
+            'email' => 'required|email',
+            'company' => 'required|string',
+        ])->validate();
+
+        $company = Company::where('id', $data['company'])
+            ->orWhere('slug', $data['company'])
+            ->orWhere('name', $data['company'])
+            ->firstOrFail();
+
+        if (!$actor->isSuperAdmin()) {
+            $active = session('current_company_id');
+            abort_if($active !== $company->id, 403);
+            $isOwner = $actor->companies()
+                ->where('auth.company_user.company_id', $company->id)
+                ->wherePivot('role', 'owner')
+                ->exists();
+            abort_unless($isOwner, 403);
+        }
+
+        DB::transaction(function () use ($data, $company) {
+            $user = User::where('email', $data['email'])->firstOrFail();
+            $company->users()->detach($user->id);
+        });
+
+        return ['message' => 'User unassigned', 'data' => ['email' => $data['email'], 'company' => $company->slug]];
+    }
+}

--- a/app/app/Actions/DevOps/UserCreate.php
+++ b/app/app/Actions/DevOps/UserCreate.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Actions\DevOps;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class UserCreate
+{
+    public function handle(array $p, User $actor): array
+    {
+        abort_unless($actor->isSuperAdmin(), 403);
+
+        $data = Validator::make($p, [
+            'name' => 'required|string',
+            'email' => 'required|email|unique:users,email',
+            'password' => 'nullable|string',
+            'system_role' => 'nullable|in:superadmin',
+        ])->validate();
+
+        $user = DB::transaction(function () use ($data) {
+            return User::create([
+                'name' => $data['name'],
+                'email' => $data['email'],
+                'password' => $data['password'] ?? Str::random(12),
+                'system_role' => $data['system_role'] ?? null,
+            ]);
+        });
+
+        return ['message' => 'User created', 'data' => ['email' => $user->email]];
+    }
+}

--- a/app/app/Actions/DevOps/UserDelete.php
+++ b/app/app/Actions/DevOps/UserDelete.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Actions\DevOps;
+
+use App\Models\User;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\DB;
+
+class UserDelete
+{
+    public function handle(array $p, User $actor): array
+    {
+        abort_unless($actor->isSuperAdmin(), 403);
+
+        $data = Validator::make($p, [
+            'email' => 'required|email',
+        ])->validate();
+
+        DB::transaction(function () use ($data) {
+            $user = User::where('email', $data['email'])->firstOrFail();
+            $user->delete();
+        });
+
+        return ['message' => 'User deleted', 'data' => ['email' => $data['email']]];
+    }
+}

--- a/app/app/Http/Controllers/CommandController.php
+++ b/app/app/Http/Controllers/CommandController.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use App\Support\CommandBus;
+
+class CommandController extends Controller
+{
+    public function execute(Request $request)
+    {
+        $action = $request->header('X-Action');
+        $key    = $request->header('X-Idempotency-Key');
+        abort_unless($action && $key, 400, 'Missing headers');
+
+        $user   = $request->user();
+        $params = $request->all();
+        $companyId = $request->session()->get('current_company_id');
+
+        if (DB::table('audit.audit_logs')->where('idempotency_key', $key)->exists()) {
+            return response()->json(['message' => 'Duplicate request'], 409);
+        }
+
+        $result = CommandBus::dispatch($action, $params, $user);
+
+        DB::table('audit.audit_logs')->insert([
+            'id' => Str::uuid()->toString(),
+            'user_id' => $user->id,
+            'company_id' => $companyId,
+            'action' => $action,
+            'params' => json_encode($params),
+            'idempotency_key' => $key,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return response()->json($result);
+    }
+}

--- a/app/app/Models/Company.php
+++ b/app/app/Models/Company.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Support\Str;
 
 class Company extends Model
 {
@@ -18,7 +19,7 @@ class Company extends Model
     protected $casts = ['settings' => 'array'];
 
 
-   protected static function booted(): void
+    protected static function booted(): void
     {
         static::creating(function (Company $company) {
             if (!$company->slug) {
@@ -34,10 +35,10 @@ class Company extends Model
     }
 
     public function users()
-{
-    return $this->belongsToMany(\App\Models\User::class, 'auth.company_user')
-        ->withPivot('role')
-        ->withTimestamps();
-}
+    {
+        return $this->belongsToMany(\App\Models\User::class, 'auth.company_user')
+            ->withPivot('role')
+            ->withTimestamps();
+    }
 
 }

--- a/app/app/Support/CommandBus.php
+++ b/app/app/Support/CommandBus.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\User;
+
+class CommandBus
+{
+    public static function dispatch(string $action, array $params, User $user): array
+    {
+        return match ($action) {
+            'user.create'      => app(\App\Actions\DevOps\UserCreate::class)->handle($params, $user),
+            'user.delete'      => app(\App\Actions\DevOps\UserDelete::class)->handle($params, $user),
+            'company.create'   => app(\App\Actions\DevOps\CompanyCreate::class)->handle($params, $user),
+            'company.delete'   => app(\App\Actions\DevOps\CompanyDelete::class)->handle($params, $user),
+            'company.assign'   => app(\App\Actions\DevOps\CompanyAssign::class)->handle($params, $user),
+            'company.unassign' => app(\App\Actions\DevOps\CompanyUnassign::class)->handle($params, $user),
+            default            => throw new \InvalidArgumentException("Unknown action: {$action}"),
+        };
+    }
+}

--- a/app/database/migrations/2025_08_28_000000_create_audit_logs_table.php
+++ b/app/database/migrations/2025_08_28_000000_create_audit_logs_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        DB::statement('CREATE SCHEMA IF NOT EXISTS audit');
+        Schema::dropIfExists('audit.audit_logs');
+        Schema::create('audit.audit_logs', function (Blueprint $t) {
+            $t->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
+            $t->uuid('user_id');
+            $t->uuid('company_id')->nullable();
+            $t->string('action');
+            $t->jsonb('params')->nullable();
+            $t->string('idempotency_key')->unique();
+            $t->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('audit.audit_logs');
+    }
+};

--- a/app/package.json
+++ b/app/package.json
@@ -7,6 +7,7 @@
         "dev": "vite"
     },
     "devDependencies": {
+        "@headlessui/vue": "^1.7.0",
         "@inertiajs/vue3": "^2.0.0",
         "@tailwindcss/forms": "^0.5.3",
         "@tailwindcss/vite": "^4.0.0",
@@ -16,6 +17,7 @@
         "axios": "^1.11.0",
         "chokidar": "^4.0.3",
         "concurrently": "^9.0.1",
+        "fuse.js": "^6.6.2",
         "laravel-vite-plugin": "^2.0.0",
         "postcss": "^8.4.31",
         "tailwindcss": "^3.2.1",

--- a/app/resources/js/Components/CommandPalette.vue
+++ b/app/resources/js/Components/CommandPalette.vue
@@ -1,0 +1,64 @@
+<!-- resources/js/Components/CommandPalette.vue -->
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import { Dialog, Combobox, ComboboxInput, ComboboxOptions, ComboboxOption } from '@headlessui/vue'
+import Fuse from 'fuse.js'
+import axios from 'axios'
+import { registry } from '@/palette/registry'
+import { parse } from '@/palette/parser'
+
+const open = ref(false)
+const size = ref<'half' | 'full'>('half')
+const query = ref('')
+const selected = ref<any|null>(null)
+const fuse = new Fuse(registry, { keys: ['label','aliases'] })
+const results = computed(() => query.value ? fuse.search(query.value).map(r => r.item) : registry)
+const extra = ref<Record<string,string>>({})
+const missing = ref<string[]>([])
+
+function submit() {
+  const text = selected.value ? selected.value.label : query.value
+  const { action, params } = parse(text)
+  Object.assign(params, extra.value)
+  missing.value = (registry.find(r => r.id === action)?.needs || [])
+    .filter(n => !params[n.replace('?','')] && !n.endsWith('?'))
+  if (missing.value.length) return
+  axios.post('/commands', params, {
+    headers: {
+      'X-Action': action,
+      'X-Idempotency-Key': crypto.randomUUID(),
+    }
+  })
+  query.value = ''
+  selected.value = null
+  extra.value = {}
+  missing.value = []
+  open.value = false
+}
+</script>
+
+<template>
+  <div class="fixed bottom-0 inset-x-0 p-2 flex justify-center space-x-2">
+    <button @click="open=true; size='half'" class="px-2 py-1 bg-gray-200 rounded">half</button>
+    <button @click="open=false" class="px-2 py-1 bg-gray-200 rounded">hide</button>
+    <button @click="open=true; size='full'" class="px-2 py-1 bg-gray-200 rounded">full</button>
+  </div>
+  <Dialog v-if="open" @close="open=false" :class="size==='full'?'fixed inset-0':'fixed inset-x-0 bottom-0 h-1/2'" class="bg-white shadow-lg">
+    <div class="p-4 flex">
+      <div class="flex-1">
+        <Combobox v-model="selected" @change="submit">
+          <ComboboxInput v-model="query" class="w-full border p-2" placeholder="Run command..." />
+          <ComboboxOptions>
+            <ComboboxOption v-for="item in results" :key="item.id" :value="item" class="px-2 py-1 hover:bg-gray-100">{{ item.label }}</ComboboxOption>
+          </ComboboxOptions>
+        </Combobox>
+      </div>
+      <div v-if="missing.length" class="w-64 ps-4 space-y-2">
+        <div v-for="m in missing" :key="m">
+          <input v-model="extra[m]" :placeholder="m" class="w-full border p-1" />
+        </div>
+        <button @click="submit" class="mt-2 px-2 py-1 bg-blue-500 text-white rounded">Run</button>
+      </div>
+    </div>
+  </Dialog>
+</template>

--- a/app/resources/js/Layouts/AuthenticatedLayout.vue
+++ b/app/resources/js/Layouts/AuthenticatedLayout.vue
@@ -8,6 +8,7 @@ import NavLink from '@/Components/NavLink.vue'
 import ResponsiveNavLink from '@/Components/ResponsiveNavLink.vue'
 import { Link } from '@inertiajs/vue3'
 import CompanySwitcher from '@/Components/CompanySwitcher.vue'   // ← add this
+import CommandPalette from '@/Components/CommandPalette.vue'
 
 const showingNavigationDropdown = ref(false)
 </script>
@@ -132,5 +133,6 @@ const showingNavigationDropdown = ref(false)
                 <slot />
             </main>
         </div>
+        <CommandPalette />
     </div>
 </template>

--- a/app/resources/js/palette/parser.ts
+++ b/app/resources/js/palette/parser.ts
@@ -1,0 +1,14 @@
+import { registry } from './registry'
+
+export function parse(input: string): { action: string; params: Record<string, string> } {
+  const tokens = input.trim().split(/\s+/)
+  const first = tokens.shift() || ''
+  const item = registry.find(r => r.id === first || r.label === first || r.aliases.includes(first))
+  const action = item ? item.id : first
+  const params: Record<string, string> = {}
+  tokens.forEach(t => {
+    const m = t.match(/^--([^=]+)=(.+)$/)
+    if (m) params[m[1]] = m[2]
+  })
+  return { action, params }
+}

--- a/app/resources/js/palette/registry.ts
+++ b/app/resources/js/palette/registry.ts
@@ -1,0 +1,8 @@
+export const registry = [
+  { id:'user.create',    label:'user create',    aliases:['user add','add user'] , needs:['name','email','password?','system_role?'] },
+  { id:'user.delete',    label:'user delete',    aliases:['user remove','remove user'], needs:['email'] },
+  { id:'company.create', label:'company create', aliases:['company add','add company'], needs:['name'] },
+  { id:'company.delete', label:'company delete', aliases:['company remove','remove company'], needs:['company'] },
+  { id:'company.assign', label:'company assign', aliases:['assign user','assign company'], needs:['email','company','role'] },
+  { id:'company.unassign',label:'company unassign',aliases:['unassign user','remove from company'], needs:['email','company'] },
+];

--- a/app/routes/web.php
+++ b/app/routes/web.php
@@ -10,6 +10,8 @@ Route::middleware(['auth','throttle:devcli'])->group(function () {
     Route::post('/dev/cli/execute', [\App\Http\Controllers\DevCliController::class, 'execute'])->name('dev.cli.execute');
 });
 
+Route::middleware(['auth', 'verified'])->post('/commands', [\App\Http\Controllers\CommandController::class, 'execute']);
+
 Route::get('/', function () {
     return Inertia::render('Welcome', [
         'canLogin' => Route::has('login'),

--- a/app/tests/Feature/CommandsApiTest.php
+++ b/app/tests/Feature/CommandsApiTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+use App\Models\User;
+use App\Models\Company;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class CommandsApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_create(): void
+    {
+        $actor = User::factory()->create(['system_role' => 'superadmin']);
+        $company = Company::factory()->create();
+        $res = $this->actingAs($actor)
+            ->withSession(['current_company_id' => $company->id])
+            ->postJson('/commands', [
+                'name' => 'Alice',
+                'email' => 'alice@example.com',
+            ], [
+                'X-Action' => 'user.create',
+                'X-Idempotency-Key' => 'u1',
+            ]);
+        $res->assertStatus(200)->assertJsonPath('data.email', 'alice@example.com');
+        $this->assertDatabaseHas('users', ['email' => 'alice@example.com']);
+    }
+
+    public function test_company_create(): void
+    {
+        $actor = User::factory()->create(['system_role' => 'superadmin']);
+        $res = $this->actingAs($actor)
+            ->withSession(['current_company_id' => null])
+            ->postJson('/commands', ['name' => 'Acme'], [
+                'X-Action' => 'company.create',
+                'X-Idempotency-Key' => 'c1',
+            ]);
+        $res->assertStatus(200);
+        $this->assertNotEmpty($res->json('data.slug'));
+        $this->assertDatabaseHas('auth.companies', ['name' => 'Acme']);
+    }
+
+    public function test_assign_and_unassign(): void
+    {
+        $actor = User::factory()->create(['system_role' => 'superadmin']);
+        $company = Company::factory()->create();
+        $user = User::factory()->create(['email' => 'member@example.com']);
+
+        $this->actingAs($actor)->withSession(['current_company_id' => $company->id]);
+        $this->setTenant($company->id);
+
+        $assign = $this->postJson('/commands', [
+            'email' => $user->email,
+            'company' => $company->id,
+            'role' => 'admin',
+        ], [
+            'X-Action' => 'company.assign',
+            'X-Idempotency-Key' => 'a1',
+        ]);
+        $assign->assertStatus(200);
+        $this->assertDatabaseHas('auth.company_user', ['company_id' => $company->id, 'user_id' => $user->id]);
+
+        $unassign = $this->postJson('/commands', [
+            'email' => $user->email,
+            'company' => $company->id,
+        ], [
+            'X-Action' => 'company.unassign',
+            'X-Idempotency-Key' => 'a2',
+        ]);
+        $unassign->assertStatus(200);
+        $this->assertDatabaseMissing('auth.company_user', ['company_id' => $company->id, 'user_id' => $user->id]);
+    }
+
+    public function test_idempotent_replay_returns_409(): void
+    {
+        $actor = User::factory()->create(['system_role' => 'superadmin']);
+        $company = Company::factory()->create();
+        $this->actingAs($actor)->withSession(['current_company_id' => $company->id]);
+
+        $headers = ['X-Action' => 'company.create', 'X-Idempotency-Key' => 'dup'];
+        $this->postJson('/commands', ['name' => 'Beta'], $headers)->assertStatus(200);
+        $this->postJson('/commands', ['name' => 'Beta'], $headers)->assertStatus(409);
+    }
+
+    public function test_unauthorized_assign(): void
+    {
+        $actor = User::factory()->create();
+        $company = Company::factory()->create();
+        $target = User::factory()->create(['email' => 't@example.com']);
+
+        $this->actingAs($actor)->withSession(['current_company_id' => $company->id]);
+        $this->setTenant($company->id);
+
+        $res = $this->postJson('/commands', [
+            'email' => $target->email,
+            'company' => $company->id,
+            'role' => 'admin',
+        ], [
+            'X-Action' => 'company.assign',
+            'X-Idempotency-Key' => 'z1',
+        ]);
+        $res->assertStatus(403);
+    }
+}

--- a/docs/briefs/haasib-technical-brief-and-progress_v2.1_2025-08-22.md
+++ b/docs/briefs/haasib-technical-brief-and-progress_v2.1_2025-08-22.md
@@ -375,6 +375,11 @@
 **Defers:** Financial/reporting commands (invoice, bill, payment, reconcile, P&L/BS) to Ledger Core (CLI-L1) once posting and ledger schemas are in place.
 **References:** Plan: CLI in same codebase, Artisan-first; CLI per-module in DoD; module loop adds CLI after services.
 
+### 2025-08-28 — Palette DevOps foundations
+- Transport: POST /commands (web middleware), Headless UI + Fuse palette, session tenancy.
+- Implemented action bus + DevOps actions: user create/delete, company create/delete, assign/unassign.
+- Kept DevCliController for dev-only console; both paths use same actions.
+- Tests cover success, RBAC, idempotency.
 
 > Use this template for new entries:
 >


### PR DESCRIPTION
## Summary
- route POST /commands for palette and CommandController
- DevOps action bus with user and company CRUD, assign and unassign
- Vue command palette using Headless UI + Fuse

## Testing
- `php artisan test tests/Feature/CommandsApiTest.php`
- `php artisan test` *(fails: Tests\Feature\RbacTest > member can view ledger)*

------
https://chatgpt.com/codex/tasks/task_e_68b073e209d88322917cf6c4e66b2ba5