### PR TITLE
Fix palette state references and panel element

### DIFF
--- a/app/resources/js/Components/CommandPalette.vue
+++ b/app/resources/js/Components/CommandPalette.vue
@@ -10,7 +10,7 @@ const palette = usePalette()
   const {
       open, q, step, selectedEntity, selectedVerb, params, inputEl, selectedIndex, executing, results, showResults,
       activeFlagId,
-      isSuperAdmin, userSource, companySource, mainPanelEl,
+      isSuperAdmin, userSource, companySource,
       panelItems,
       companyDetails, companyMembers, companyMembersLoading, userDetails, deleteConfirmText, deleteConfirmRequired,
       entitySuggestions, verbSuggestions, availableFlags, filledFlags, currentField, dashParameterMatch, allRequiredFilled, currentChoices,
@@ -25,6 +25,8 @@ const palette = usePalette()
   pickUserEmail, pickCompanyName, pickGeneric,
   performUIListAction,
 } = palette
+
+const mainPanelEl = ref<HTMLDivElement | null>(null)
 
 // Focus management for delete confirmation input (company delete)
 const deleteConfirmInputEl = ref<HTMLInputElement | null>(null)

--- a/app/resources/js/palette/composables/usePalette.ts
+++ b/app/resources/js/palette/composables/usePalette.ts
@@ -634,11 +634,18 @@ export function usePalette() {
   })
 
   // Populate panel items for UI list actions (companies/users)
-  watch([isUIList, () => state.step, () => state.q, companySource, userSource, () => state.params.email, () => state.selectedVerb], async ([isList, currentStep, qVal, coSource, uSource, email, verb]) => {
-    if (!isList || currentStep !== 'fields' || !verb) return
-    const verb = state.selectedVerb
-    if (verb && verb.fields.length > 0) {
-      const fieldDef = verb.fields[0]
+  watch([
+    isUIList,
+    () => state.step,
+    () => state.q,
+    companySource,
+    userSource,
+    () => state.params.email,
+    () => state.selectedVerb,
+  ], async ([isList, currentStep, qVal, coSource, uSource, email, selectedVerb]) => {
+    if (!isList || currentStep !== 'fields' || !selectedVerb) return
+    if (selectedVerb && selectedVerb.fields.length > 0) {
+      const fieldDef = selectedVerb.fields[0]
       try {
         const items = await provider.fromField(fieldDef, state.q, state.params)
         panelItems.value = items
@@ -683,8 +690,7 @@ export function usePalette() {
   }
 
   const api = {
-    open, q, step, selectedEntity, selectedVerb, params, inputEl, selectedIndex, executing, results, showResults, stashParams,
-    activeFlagId, flagAnimating, editingFlagId, deleteConfirmText, deleteConfirmRequired,
+    inputEl,
     isSuperAdmin, currentCompanyId, userSource, companySource,
     panelItems, inlineItems, // Replaces userOptions, companyOptions, etc.
     companyDetails, companyMembers, companyMembersLoading, userDetails,
@@ -692,7 +698,7 @@ export function usePalette() {
     isUIList, showUserPicker, showCompanyPicker, showGenericPanelPicker, inlineSuggestions,
     highlightedUser, highlightedCompany, highlightedItem,
     statusText, getTabCompletion,
-    uiListActionMode, uiListActionIndex, uiListActionCount,
+    uiListActionCount,
     animateFlag, selectFlag, editFilledFlag, completeCurrentFlag, cycleToLastFilledFlag, handleDashParameter,
     loadCompanyMembers, ensureCompanyDetails, startVerb, quickAssignToCompany, setActiveCompany, quickAssignUserToCompany, quickUnassignUserFromCompany,
     resetAll, goHome, goBack,


### PR DESCRIPTION
## Summary
- avoid undefined state refs in `usePalette` API
- handle panel element locally in `CommandPalette`
- remove duplicate `verb` declaration in palette watcher

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not resolve "../../vendor/tightenco/ziggy" from "resources/js/app.js")*

------
https://chatgpt.com/codex/tasks/task_e_68b8682e590083229e1125e2e4c8dc52