### PR TITLE
Fix palette state references and panel element

### DIFF
--- a/app/resources/js/Components/CommandPalette.vue
+++ b/app/resources/js/Components/CommandPalette.vue
@@ -1,7 +1,7 @@
 <!-- resources/js/Components/CommandPalette.vue -->
 <script setup lang="ts">
 import { onMounted, onUnmounted, nextTick, ref, computed, watch } from 'vue'
-import { Dialog, DialogPanel } from '@headlessui/vue'
+import { DialogRoot, DialogPortal, DialogOverlay, DialogContent } from 'reka-ui'
 import SuggestList from '@/Components/SuggestList.vue'
 import { usePalette } from '@/palette/composables/usePalette'
 import { usePaletteKeybindings } from '@/palette/composables/usePaletteKeybindings'
@@ -10,7 +10,7 @@ const palette = usePalette()
   const {
       open, q, step, selectedEntity, selectedVerb, params, inputEl, selectedIndex, executing, results, showResults,
       activeFlagId,
-      isSuperAdmin, userSource, companySource, mainPanelEl,
+      isSuperAdmin, userSource, companySource,
       panelItems,
       companyDetails, companyMembers, companyMembersLoading, userDetails, deleteConfirmText, deleteConfirmRequired,
       entitySuggestions, verbSuggestions, availableFlags, filledFlags, currentField, dashParameterMatch, allRequiredFilled, currentChoices,
@@ -25,6 +25,8 @@ const palette = usePalette()
   pickUserEmail, pickCompanyName, pickGeneric,
   performUIListAction,
 } = palette
+
+const mainPanelEl = ref<HTMLDivElement | null>(null)
 
 // Focus management for delete confirmation input (company delete)
 const deleteConfirmInputEl = ref<HTMLInputElement | null>(null)
@@ -198,18 +200,19 @@ onUnmounted(() => {
     </div>
   </div>
 
-  <Dialog :open="isExpanded" @close="collapseToStrip()" class="relative z-50">
-    <div class="fixed inset-0 bg-black/70 backdrop-blur-sm" aria-hidden="true"></div>
+  <DialogRoot :open="isExpanded" @update:open="(v) => { if (!v) collapseToStrip() }" class="relative z-50">
+    <DialogPortal>
+      <DialogOverlay class="fixed inset-0 bg-black/70 backdrop-blur-sm" />
 
-    <div class="fixed inset-x-0 bottom-0 flex items-end justify-center pb-2 sm:pb-4 px-2">
-      <div class="w-full max-w-5xl flex flex-col lg:flex-row gap-4"
-           :class="[showResults ? 'lg:max-w-5xl' : '', dockSize==='full' ? 'h-[88vh]' : 'h-[56vh]']">
+      <div class="fixed inset-x-0 bottom-0 flex items-end justify-center pb-2 sm:pb-4 px-2">
+        <DialogContent class="w-full max-w-5xl flex flex-col lg:flex-row gap-4"
+                       :class="[showResults ? 'lg:max-w-5xl' : '', dockSize==='full' ? 'h-[88vh]' : 'h-[56vh]']">
 
-        <!-- Main Command Palette - Enhanced design -->
-        <DialogPanel class="flex-1 bg-gray-900/95 backdrop-blur-md border border-gray-700 rounded-t-xl shadow-2xl font-mono text-sm overflow-hidden"
-                     :class="isExpanded ? 'scale-100 opacity-100' : 'scale-105 opacity-0'"
-                     @keydown="(e) => { if (e.key === 'Escape') { e.preventDefault(); e.stopPropagation(); goBack() } }">
-          <div class="flex flex-col h-full" @keydown="handleKeydown" ref="mainPanelEl" tabindex="-1">
+          <!-- Main Command Palette - Enhanced design -->
+          <div class="flex-1 bg-gray-900/95 backdrop-blur-md border border-gray-700 rounded-t-xl shadow-2xl font-mono text-sm overflow-hidden"
+                       :class="isExpanded ? 'scale-100 opacity-100' : 'scale-105 opacity-0'"
+                       @keydown="(e) => { if (e.key === 'Escape') { e.preventDefault(); e.stopPropagation(); goBack() } }">
+            <div class="flex flex-col h-full" @keydown="handleKeydown" ref="mainPanelEl" tabindex="-1">
 
             <!-- Terminal Header - Enhanced -->
             <div class="px-4 py-3 border-b border-gray-700/50 bg-gradient-to-r from-gray-800 to-gray-900">
@@ -584,7 +587,7 @@ onUnmounted(() => {
               </div>
             </div>
           </div>
-        </DialogPanel>
+        </div>
 
         <!-- Results Panel - Enhanced -->
         <div v-if="showResults && results.length > 0"
@@ -626,9 +629,10 @@ onUnmounted(() => {
             </div>
           </div>
         </div>
+        </DialogContent>
       </div>
-    </div>
-  </Dialog>
+    </DialogPortal>
+  </DialogRoot>
 </template>
 
 <style scoped>

--- a/app/resources/js/palette/composables/usePalette.ts
+++ b/app/resources/js/palette/composables/usePalette.ts
@@ -634,11 +634,18 @@ export function usePalette() {
   })
 
   // Populate panel items for UI list actions (companies/users)
-  watch([isUIList, () => state.step, () => state.q, companySource, userSource, () => state.params.email, () => state.selectedVerb], async ([isList, currentStep, qVal, coSource, uSource, email, verb]) => {
-    if (!isList || currentStep !== 'fields' || !verb) return
-    const verb = state.selectedVerb
-    if (verb && verb.fields.length > 0) {
-      const fieldDef = verb.fields[0]
+  watch([
+    isUIList,
+    () => state.step,
+    () => state.q,
+    companySource,
+    userSource,
+    () => state.params.email,
+    () => state.selectedVerb,
+  ], async ([isList, currentStep, qVal, coSource, uSource, email, selectedVerb]) => {
+    if (!isList || currentStep !== 'fields' || !selectedVerb) return
+    if (selectedVerb && selectedVerb.fields.length > 0) {
+      const fieldDef = selectedVerb.fields[0]
       try {
         const items = await provider.fromField(fieldDef, state.q, state.params)
         panelItems.value = items
@@ -683,8 +690,7 @@ export function usePalette() {
   }
 
   const api = {
-    open, q, step, selectedEntity, selectedVerb, params, inputEl, selectedIndex, executing, results, showResults, stashParams,
-    activeFlagId, flagAnimating, editingFlagId, deleteConfirmText, deleteConfirmRequired,
+    inputEl,
     isSuperAdmin, currentCompanyId, userSource, companySource,
     panelItems, inlineItems, // Replaces userOptions, companyOptions, etc.
     companyDetails, companyMembers, companyMembersLoading, userDetails,
@@ -692,7 +698,7 @@ export function usePalette() {
     isUIList, showUserPicker, showCompanyPicker, showGenericPanelPicker, inlineSuggestions,
     highlightedUser, highlightedCompany, highlightedItem,
     statusText, getTabCompletion,
-    uiListActionMode, uiListActionIndex, uiListActionCount,
+    uiListActionCount,
     animateFlag, selectFlag, editFilledFlag, completeCurrentFlag, cycleToLastFilledFlag, handleDashParameter,
     loadCompanyMembers, ensureCompanyDetails, startVerb, quickAssignToCompany, setActiveCompany, quickAssignUserToCompany, quickUnassignUserFromCompany,
     resetAll, goHome, goBack,


### PR DESCRIPTION
## Summary
- avoid undefined state refs in `usePalette` API
- handle panel element locally in `CommandPalette`
- remove duplicate `verb` declaration in palette watcher
- replace Headless UI dialog with Reka UI components in `CommandPalette`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Could not resolve "../../vendor/tightenco/ziggy" from "resources/js/app.js")*

------
https://chatgpt.com/codex/tasks/task_e_68b8682e590083229e1125e2e4c8dc52