### PR TITLE
feat: extract command execution service

### DIFF
--- a/app/app/Http/Controllers/CommandController.php
+++ b/app/app/Http/Controllers/CommandController.php
@@ -3,16 +3,11 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Schema;
-use Illuminate\Support\Str;
-use App\Support\CommandBus;
-use Illuminate\Validation\ValidationException;
-use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use App\Services\CommandExecutor;
 
 class CommandController extends Controller
 {
-    public function execute(Request $request)
+    public function execute(Request $request, CommandExecutor $executor)
     {
         $action = $request->header('X-Action');
         $key    = $request->header('X-Idempotency-Key');
@@ -22,78 +17,8 @@ class CommandController extends Controller
         $params = $request->all();
         $companyId = $request->session()->get('current_company_id');
 
-        // Idempotency check (scoped by user/company/action/key)
-        try {
-            if (Schema::hasTable('idempotency_keys')) {
-                $exists = DB::table('idempotency_keys')->where([
-                    'user_id' => $user->id,
-                    'company_id' => $companyId,
-                    'action' => $action,
-                    'key' => $key,
-                ])->exists();
-                if ($exists) {
-                    return response()->json(['message' => 'Duplicate request'], 409);
-                }
-            }
-        } catch (\Throwable $e) {
-            // If table missing or any driver error, skip idempotency check rather than 500
-        }
+        [$body, $status] = $executor->execute($action, $params, $user, $companyId, $key);
 
-        try {
-            $result = CommandBus::dispatch($action, $params, $user);
-        } catch (ValidationException $e) {
-            return response()->json([
-                'ok' => false,
-                'message' => 'Validation failed',
-                'errors' => $e->errors(),
-            ], 422);
-        } catch (HttpExceptionInterface $e) {
-            return response()->json([
-                'ok' => false,
-                'message' => $e->getMessage() ?: 'Request not allowed',
-            ], $e->getStatusCode());
-        } catch (\Throwable $e) {
-            return response()->json([
-                'ok' => false,
-                'message' => 'Command failed',
-                'error' => $e->getMessage(),
-            ], 500);
-        }
-
-        try {
-            DB::table('audit.audit_logs')->insert([
-                'id' => Str::uuid()->toString(),
-                'user_id' => $user->id,
-                'company_id' => $companyId,
-                'action' => $action,
-                'params' => json_encode($params),
-                'idempotency_key' => $key,
-                'created_at' => now(),
-                'updated_at' => now(),
-            ]);
-        } catch (\Throwable $e) {
-            // Log write failure should not block the command response
-        }
-
-        // Record idempotency key for future replays
-        try {
-            if (Schema::hasTable('idempotency_keys')) {
-                DB::table('idempotency_keys')->insert([
-                    'id' => Str::uuid()->toString(),
-                    'user_id' => $user->id,
-                    'company_id' => $companyId,
-                    'action' => $action,
-                    'key' => $key,
-                    'request' => json_encode($params),
-                    'response' => json_encode($result),
-                    'created_at' => now(),
-                    'updated_at' => now(),
-                ]);
-            }
-        } catch (\Throwable $e) {
-            // ignore
-        }
-
-        return response()->json($result);
+        return response()->json($body, $status);
     }
 }

--- a/app/app/Services/CommandExecutor.php
+++ b/app/app/Services/CommandExecutor.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\User;
+use App\Support\CommandBus;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+
+class CommandExecutor
+{
+    public function execute(string $action, array $params, User $user, ?int $companyId, string $key): array
+    {
+        // Idempotency check (scoped by user/company/action/key)
+        try {
+            if (Schema::hasTable('idempotency_keys')) {
+                $exists = DB::table('idempotency_keys')->where([
+                    'user_id' => $user->id,
+                    'company_id' => $companyId,
+                    'action' => $action,
+                    'key' => $key,
+                ])->exists();
+
+                if ($exists) {
+                    return [['message' => 'Duplicate request'], 409];
+                }
+            }
+        } catch (\Throwable $e) {
+            // If table missing or any driver error, skip idempotency check rather than 500
+        }
+
+        try {
+            $result = CommandBus::dispatch($action, $params, $user);
+        } catch (ValidationException $e) {
+            return [[
+                'ok' => false,
+                'message' => 'Validation failed',
+                'errors' => $e->errors(),
+            ], 422];
+        } catch (HttpExceptionInterface $e) {
+            return [[
+                'ok' => false,
+                'message' => $e->getMessage() ?: 'Request not allowed',
+            ], $e->getStatusCode()];
+        } catch (\Throwable $e) {
+            return [[
+                'ok' => false,
+                'message' => 'Command failed',
+                'error' => $e->getMessage(),
+            ], 500];
+        }
+
+        try {
+            DB::table('audit.audit_logs')->insert([
+                'id' => Str::uuid()->toString(),
+                'user_id' => $user->id,
+                'company_id' => $companyId,
+                'action' => $action,
+                'params' => json_encode($params),
+                'idempotency_key' => $key,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        } catch (\Throwable $e) {
+            // Log write failure should not block the command response
+        }
+
+        // Record idempotency key for future replays
+        try {
+            if (Schema::hasTable('idempotency_keys')) {
+                DB::table('idempotency_keys')->insert([
+                    'id' => Str::uuid()->toString(),
+                    'user_id' => $user->id,
+                    'company_id' => $companyId,
+                    'action' => $action,
+                    'key' => $key,
+                    'request' => json_encode($params),
+                    'response' => json_encode($result),
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ]);
+            }
+        } catch (\Throwable $e) {
+            // ignore
+        }
+
+        return [$result, 200];
+    }
+}


### PR DESCRIPTION
## Summary
- add CommandExecutor service to manage idempotency, auditing, and command dispatching
- simplify CommandController to delegate execution to new service

## Testing
- `composer test` *(fails: connection to PostgreSQL at 127.0.0.1:5432 refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b92a2ea3208322aec778b09bef664c