### PR TITLE
Add invitation service for managing company invites

### DIFF
--- a/app/app/Http/Controllers/InvitationController.php
+++ b/app/app/Http/Controllers/InvitationController.php
@@ -2,143 +2,48 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Company;
+use App\Services\InvitationService;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Str;
 
 class InvitationController extends Controller
 {
+    public function __construct(private InvitationService $invitations)
+    {
+    }
+
     public function companyInvitations(Request $request, string $company)
     {
-        $auth = $request->user();
-
-        // Resolve company by id or slug or name
-        $q = \App\Models\Company::query();
-        if (\Illuminate\Support\Str::isUuid($company)) {
-            $q->where('id', $company);
-        } else {
-            $q->where(function ($w) use ($company) {
-                $w->where('slug', $company)->orWhere('name', $company);
-            });
-        }
-        $co = $q->firstOrFail(['id','name','slug']);
-
-        // Permission: owner/admin or superadmin
-        $allowed = $auth->isSuperAdmin() || \Illuminate\Support\Facades\DB::table('auth.company_user')
-            ->where('company_id', $co->id)
-            ->where('user_id', $auth->id)
-            ->whereIn('role', ['owner','admin'])
-            ->exists();
-        abort_unless($allowed, 403);
-
-        $status = $request->query('status', 'pending');
-
-        $rows = \Illuminate\Support\Facades\DB::table('auth.company_invitations as i')
-            ->leftJoin('users as u', 'u.id', '=', 'i.invited_by_user_id')
-            ->where('i.company_id', $co->id)
-            ->when($status, fn($w) => $w->where('i.status', $status))
-            ->orderByDesc('i.created_at')
-            ->get(['i.id','i.invited_email as email','i.role','i.status','i.expires_at','i.created_at','u.name as invited_by']);
+        $rows = $this->invitations->listCompanyInvitations(
+            $request->user(),
+            $company,
+            $request->query('status', 'pending'),
+        );
 
         return response()->json(['data' => $rows]);
     }
+
     public function myInvitations(Request $request)
     {
-        $user = $request->user();
-        $email = Str::lower($user->email);
-
-        $rows = DB::table('auth.company_invitations as i')
-            ->join('auth.companies as c', 'c.id', '=', 'i.company_id')
-            ->leftJoin('users as u', 'u.id', '=', 'i.invited_by_user_id')
-            ->where('i.status', 'pending')
-            ->where('i.invited_email', $email)
-            ->where(function ($q) {
-                $q->whereNull('i.expires_at')->orWhere('i.expires_at', '>', now());
-            })
-            ->orderBy('i.created_at', 'desc')
-            ->get(['i.id','i.company_id','c.name as company_name','i.role','i.expires_at','i.created_at','u.name as invited_by','i.token']);
+        $rows = $this->invitations->listUserInvitations($request->user());
 
         return response()->json(['data' => $rows]);
     }
 
     public function accept(Request $request, string $token)
     {
-        $auth = $request->user();
-        $now = now();
+        $companyId = $this->invitations->accept(
+            $request->user(),
+            $token,
+            $request->query('user_id'),
+        );
 
-        $inv = DB::table('auth.company_invitations')->where('token', $token)->first();
-        abort_unless($inv, 404, 'Invitation not found');
-
-        // Expiry / status checks
-        abort_if($inv->status !== 'pending', 422, 'Invitation is not pending');
-        if ($inv->expires_at && $inv->expires_at <= $now) {
-            DB::table('auth.company_invitations')->where('id', $inv->id)->update(['status' => 'expired', 'updated_at' => $now]);
-            abort(422, 'Invitation expired');
-        }
-
-        // Only the invited user can accept; superadmin can override by providing ?user_id=...
-        $targetUserId = $auth->id;
-        if ($auth->isSuperAdmin() && $request->filled('user_id')) {
-            $targetUserId = $request->query('user_id');
-        } else {
-            // Ensure email matches
-            abort_unless(Str::lower($auth->email) === Str::lower($inv->invited_email), 403, 'This invite is for a different email');
-        }
-
-        // Attach membership idempotently; update role if exists
-        DB::transaction(function () use ($inv, $targetUserId, $now, $auth) {
-            $exists = DB::table('auth.company_user')
-                ->where('company_id', $inv->company_id)
-                ->where('user_id', $targetUserId)
-                ->exists();
-
-            if ($exists) {
-                DB::table('auth.company_user')
-                    ->where('company_id', $inv->company_id)
-                    ->where('user_id', $targetUserId)
-                    ->update([
-                        'role' => $inv->role,
-                        'invited_by_user_id' => $inv->invited_by_user_id ?? $auth->id,
-                        'updated_at' => $now,
-                    ]);
-            } else {
-                DB::table('auth.company_user')->insert([
-                    'company_id' => $inv->company_id,
-                    'user_id' => $targetUserId,
-                    'role' => $inv->role,
-                    'invited_by_user_id' => $inv->invited_by_user_id ?? $auth->id,
-                    'created_at' => $now,
-                    'updated_at' => $now,
-                ]);
-            }
-
-            DB::table('auth.company_invitations')->where('id', $inv->id)->update([
-                'status' => 'accepted',
-                'accepted_at' => $now,
-                'accepted_by_user_id' => $targetUserId,
-                'updated_at' => $now,
-            ]);
-        });
-
-        return response()->json(['message' => 'Invitation accepted', 'company_id' => $inv->company_id]);
+        return response()->json(['message' => 'Invitation accepted', 'company_id' => $companyId]);
     }
 
     public function revoke(Request $request, string $id)
     {
-        $auth = $request->user();
-        $inv = DB::table('auth.company_invitations')->where('id', $id)->first();
-        abort_unless($inv, 404);
+        $this->invitations->revoke($request->user(), $id);
 
-        // Permission: inviter, an admin/owner of company, or superadmin
-        $allowed = $auth->isSuperAdmin() || $inv->invited_by_user_id === $auth->id || DB::table('auth.company_user')
-            ->where('company_id', $inv->company_id)
-            ->where('user_id', $auth->id)
-            ->whereIn('role', ['owner','admin'])
-            ->exists();
-        abort_unless($allowed, 403);
-
-        DB::table('auth.company_invitations')->where('id', $id)->update(['status' => 'revoked', 'updated_at' => now()]);
         return response()->json(['message' => 'Invitation revoked']);
     }
 }

--- a/app/app/Models/CompanyInvitation.php
+++ b/app/app/Models/CompanyInvitation.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+
+class CompanyInvitation extends Model
+{
+    use HasFactory, HasUuids;
+
+    /**
+     * The table associated with the model.
+     */
+    protected $table = 'auth.company_invitations';
+
+    public $incrementing = false;
+
+    protected $keyType = 'string';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'company_id',
+        'invited_email',
+        'role',
+        'invited_by_user_id',
+        'token',
+        'status',
+        'expires_at',
+        'accepted_at',
+        'accepted_by_user_id',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'expires_at' => 'datetime',
+        'accepted_at' => 'datetime',
+    ];
+
+    public function company()
+    {
+        return $this->belongsTo(Company::class);
+    }
+
+    public function inviter()
+    {
+        return $this->belongsTo(User::class, 'invited_by_user_id');
+    }
+
+    public function acceptor()
+    {
+        return $this->belongsTo(User::class, 'accepted_by_user_id');
+    }
+}

--- a/app/app/Services/InvitationService.php
+++ b/app/app/Services/InvitationService.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Company;
+use App\Models\User;
+use App\Models\CompanyInvitation;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class InvitationService
+{
+    /**
+     * List invitations for a given company.
+     */
+    public function listCompanyInvitations(User $auth, string $company, ?string $status = 'pending')
+    {
+        // Resolve company by id, slug or name
+        $q = Company::query();
+        if (Str::isUuid($company)) {
+            $q->where('id', $company);
+        } else {
+            $q->where(function ($w) use ($company) {
+                $w->where('slug', $company)->orWhere('name', $company);
+            });
+        }
+        $co = $q->firstOrFail(['id', 'name', 'slug']);
+
+        // Permission check: owner/admin or superadmin
+        $allowed = $auth->isSuperAdmin() || DB::table('auth.company_user')
+            ->where('company_id', $co->id)
+            ->where('user_id', $auth->id)
+            ->whereIn('role', ['owner', 'admin'])
+            ->exists();
+        abort_unless($allowed, 403);
+
+        return CompanyInvitation::query()
+            ->from('auth.company_invitations as i')
+            ->leftJoin('users as u', 'u.id', '=', 'i.invited_by_user_id')
+            ->where('i.company_id', $co->id)
+            ->when($status, fn($w) => $w->where('i.status', $status))
+            ->orderByDesc('i.created_at')
+            ->get([
+                'i.id',
+                'i.invited_email as email',
+                'i.role',
+                'i.status',
+                'i.expires_at',
+                'i.created_at',
+                'u.name as invited_by',
+            ]);
+    }
+
+    /**
+     * List invitations for the authenticated user.
+     */
+    public function listUserInvitations(User $user)
+    {
+        $email = Str::lower($user->email);
+
+        return CompanyInvitation::query()
+            ->from('auth.company_invitations as i')
+            ->join('auth.companies as c', 'c.id', '=', 'i.company_id')
+            ->leftJoin('users as u', 'u.id', '=', 'i.invited_by_user_id')
+            ->where('i.status', 'pending')
+            ->where('i.invited_email', $email)
+            ->where(function ($q) {
+                $q->whereNull('i.expires_at')->orWhere('i.expires_at', '>', now());
+            })
+            ->orderBy('i.created_at', 'desc')
+            ->get([
+                'i.id',
+                'i.company_id',
+                'c.name as company_name',
+                'i.role',
+                'i.expires_at',
+                'i.created_at',
+                'u.name as invited_by',
+                'i.token',
+            ]);
+    }
+
+    /**
+     * Accept an invitation and attach user to company.
+     */
+    public function accept(User $auth, string $token, ?string $userId = null): string
+    {
+        $now = now();
+
+        $inv = CompanyInvitation::where('token', $token)->first();
+        abort_unless($inv, 404, 'Invitation not found');
+
+        abort_if($inv->status !== 'pending', 422, 'Invitation is not pending');
+        if ($inv->expires_at && $inv->expires_at <= $now) {
+            $inv->update(['status' => 'expired', 'updated_at' => $now]);
+            abort(422, 'Invitation expired');
+        }
+
+        // Determine target user
+        $targetUserId = $auth->id;
+        if ($auth->isSuperAdmin() && $userId) {
+            $targetUserId = $userId;
+        } else {
+            abort_unless(Str::lower($auth->email) === Str::lower($inv->invited_email), 403, 'This invite is for a different email');
+        }
+
+        DB::transaction(function () use ($inv, $targetUserId, $now, $auth) {
+            $exists = DB::table('auth.company_user')
+                ->where('company_id', $inv->company_id)
+                ->where('user_id', $targetUserId)
+                ->exists();
+
+            if ($exists) {
+                DB::table('auth.company_user')
+                    ->where('company_id', $inv->company_id)
+                    ->where('user_id', $targetUserId)
+                    ->update([
+                        'role' => $inv->role,
+                        'invited_by_user_id' => $inv->invited_by_user_id ?? $auth->id,
+                        'updated_at' => $now,
+                    ]);
+            } else {
+                DB::table('auth.company_user')->insert([
+                    'company_id' => $inv->company_id,
+                    'user_id' => $targetUserId,
+                    'role' => $inv->role,
+                    'invited_by_user_id' => $inv->invited_by_user_id ?? $auth->id,
+                    'created_at' => $now,
+                    'updated_at' => $now,
+                ]);
+            }
+
+            $inv->update([
+                'status' => 'accepted',
+                'accepted_at' => $now,
+                'accepted_by_user_id' => $targetUserId,
+                'updated_at' => $now,
+            ]);
+        });
+
+        return $inv->company_id;
+    }
+
+    /**
+     * Revoke an invitation.
+     */
+    public function revoke(User $auth, string $id): void
+    {
+        $inv = CompanyInvitation::find($id);
+        abort_unless($inv, 404);
+
+        // Permission: inviter, admin/owner of company, or superadmin
+        $allowed = $auth->isSuperAdmin() || $inv->invited_by_user_id === $auth->id || DB::table('auth.company_user')
+            ->where('company_id', $inv->company_id)
+            ->where('user_id', $auth->id)
+            ->whereIn('role', ['owner', 'admin'])
+            ->exists();
+        abort_unless($allowed, 403);
+
+        $inv->update(['status' => 'revoked', 'updated_at' => now()]);
+    }
+}


### PR DESCRIPTION
## Summary
- add `CompanyInvitation` model
- introduce `InvitationService` to handle listing, accepting, and revoking
- refactor `InvitationController` to delegate to the service

## Testing
- `composer test` *(fails: SQLSTATE[08006] connection to server at "127.0.0.1", port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b92a4d66288322ba01b484a7d38ccc