### PR TITLE
Use registry to map command actions to handler classes

### DIFF
--- a/app/app/Support/CommandBus.php
+++ b/app/app/Support/CommandBus.php
@@ -8,14 +8,12 @@ class CommandBus
 {
     public static function dispatch(string $action, array $params, User $user): array
     {
-        return match ($action) {
-            'user.create'      => app(\App\Actions\DevOps\UserCreate::class)->handle($params, $user),
-            'user.delete'      => app(\App\Actions\DevOps\UserDelete::class)->handle($params, $user),
-            'company.create'   => app(\App\Actions\DevOps\CompanyCreate::class)->handle($params, $user),
-            'company.delete'   => app(\App\Actions\DevOps\CompanyDelete::class)->handle($params, $user),
-            'company.assign'   => app(\App\Actions\DevOps\CompanyAssign::class)->handle($params, $user),
-            'company.unassign' => app(\App\Actions\DevOps\CompanyUnassign::class)->handle($params, $user),
-            default            => throw new \InvalidArgumentException("Unknown action: {$action}"),
-        };
+        $handlerClass = config("command-bus.{$action}");
+
+        if (! $handlerClass) {
+            throw new \InvalidArgumentException("Unknown action: {$action}");
+        }
+
+        return app($handlerClass)->handle($params, $user);
     }
 }

--- a/app/config/command-bus.php
+++ b/app/config/command-bus.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'user.create' => App\Actions\DevOps\UserCreate::class,
+    'user.delete' => App\Actions\DevOps\UserDelete::class,
+    'company.create' => App\Actions\DevOps\CompanyCreate::class,
+    'company.delete' => App\Actions\DevOps\CompanyDelete::class,
+    'company.assign' => App\Actions\DevOps\CompanyAssign::class,
+    'company.unassign' => App\Actions\DevOps\CompanyUnassign::class,
+];
+


### PR DESCRIPTION
## Summary
- add config-based registry that maps action strings to handler classes
- resolve CommandBus handlers via registry instead of match expression

## Testing
- `composer test` *(fails: connection to server at "127.0.0.1", port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b92a75d28c8322b466522ae4972b5f