### PR TITLE
refactor: split palette composables

### DIFF
--- a/usePalette.ts
+++ b/usePalette.ts
@@ -1,0 +1,21 @@
+import { usePaletteState } from './usePaletteState'
+import {
+  usePaletteSuggestions,
+  type PaletteItem,
+} from './usePaletteSuggestions'
+import { usePaletteExecutor } from './usePaletteExecutor'
+
+export function usePalette(items: PaletteItem[]) {
+  const state = usePaletteState()
+  const suggestionsApi = usePaletteSuggestions(state.query, items, state.selected)
+  const executor = usePaletteExecutor(suggestionsApi.suggestions, state.selected)
+
+  return {
+    ...state,
+    ...suggestionsApi,
+    ...executor,
+  }
+}
+
+export type { PaletteItem }
+export default usePalette

--- a/usePaletteExecutor.ts
+++ b/usePaletteExecutor.ts
@@ -1,0 +1,20 @@
+import type { Ref } from 'vue'
+import type { PaletteItem } from './usePaletteSuggestions'
+
+export interface PaletteExecutor {
+  execute: () => void
+}
+
+export function usePaletteExecutor(
+  suggestions: Ref<PaletteItem[]>,
+  selected: Ref<number>
+): PaletteExecutor {
+  function execute() {
+    const item = suggestions.value[selected.value]
+    if (item) item.action()
+  }
+
+  return { execute }
+}
+
+export default usePaletteExecutor

--- a/usePaletteState.ts
+++ b/usePaletteState.ts
@@ -1,0 +1,40 @@
+import { ref, type Ref } from 'vue'
+
+export interface PaletteState {
+  /** Whether the palette is currently shown */
+  isOpen: Ref<boolean>
+  /** User's current search query */
+  query: Ref<string>
+  /** Index of the highlighted suggestion */
+  selected: Ref<number>
+  /** Show the palette */
+  open: () => void
+  /** Hide the palette */
+  close: () => void
+}
+
+export function usePaletteState(): PaletteState {
+  const isOpen = ref(false)
+  const query = ref('')
+  const selected = ref(0)
+
+  function open() {
+    isOpen.value = true
+  }
+
+  function close() {
+    isOpen.value = false
+    selected.value = 0
+    query.value = ''
+  }
+
+  return {
+    isOpen,
+    query,
+    selected,
+    open,
+    close,
+  }
+}
+
+export default usePaletteState

--- a/usePaletteSuggestions.ts
+++ b/usePaletteSuggestions.ts
@@ -1,0 +1,43 @@
+import { computed, type Ref } from 'vue'
+
+export interface PaletteItem {
+  title: string
+  action: () => void
+}
+
+export interface PaletteSuggestions {
+  suggestions: Ref<PaletteItem[]>
+  next: () => void
+  prev: () => void
+}
+
+export function usePaletteSuggestions(
+  query: Ref<string>,
+  items: PaletteItem[],
+  selected: Ref<number>
+): PaletteSuggestions {
+  const suggestions = computed(() => {
+    const q = query.value.toLowerCase().trim()
+    return items.filter((i) => i.title.toLowerCase().includes(q))
+  })
+
+  function next() {
+    const total = suggestions.value.length
+    if (total === 0) return
+    selected.value = (selected.value + 1) % total
+  }
+
+  function prev() {
+    const total = suggestions.value.length
+    if (total === 0) return
+    selected.value = (selected.value - 1 + total) % total
+  }
+
+  return {
+    suggestions,
+    next,
+    prev,
+  }
+}
+
+export default usePaletteSuggestions


### PR DESCRIPTION
## Summary
- add palette state composable for base state management
- extract suggestions logic into its own composable
- create executor composable and compose them in usePalette

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b92a8fa8fc83228720ea086b1d9ce1