### PR TITLE
refactor: add company membership repository

### DIFF
--- a/app/app/Http/Controllers/MeController.php
+++ b/app/app/Http/Controllers/MeController.php
@@ -4,7 +4,7 @@
 namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\DB;
+use App\Repositories\CompanyMembershipRepository;
 
 class MeController extends Controller
 {
@@ -22,10 +22,8 @@ class MeController extends Controller
         ]);
 
         $user = $request->user();
-        $isMember = DB::table('auth.company_user')
-            ->where('user_id', $user->id)
-            ->where('company_id', $data['company_id'])
-            ->exists();
+        $repo = app(CompanyMembershipRepository::class);
+        $isMember = $repo->verifyMembership($user->id, $data['company_id']);
 
         if (!$isMember) {
             return response()->json(['message' => 'Not a member of that company'], 403);
@@ -37,3 +35,4 @@ class MeController extends Controller
         return response()->json(['ok' => true]);
     }
 }
+

--- a/app/app/Repositories/CompanyMembershipRepository.php
+++ b/app/app/Repositories/CompanyMembershipRepository.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Repositories;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Collection;
+
+class CompanyMembershipRepository
+{
+    public function verifyMembership(string $userId, string $companyId): bool
+    {
+        return DB::table('auth.company_user')
+            ->where('user_id', $userId)
+            ->where('company_id', $companyId)
+            ->exists();
+    }
+
+    public function roleForUser(string $userId, string $companyId): ?string
+    {
+        return DB::table('auth.company_user')
+            ->where('user_id', $userId)
+            ->where('company_id', $companyId)
+            ->value('role');
+    }
+
+    public function memberships(string $userId): Collection
+    {
+        return DB::table('auth.company_user as cu')
+            ->join('auth.companies as c', 'c.id', '=', 'cu.company_id')
+            ->where('cu.user_id', $userId)
+            ->orderBy('c.name')
+            ->get([
+                'c.id',
+                'c.name',
+                'c.slug',
+                'cu.role',
+                'cu.created_at',
+                'cu.updated_at',
+            ]);
+    }
+
+    public function membersPreview(string $companyId, int $limit = 10): Collection
+    {
+        return DB::table('auth.company_user as cu')
+            ->join('users as u', 'u.id', '=', 'cu.user_id')
+            ->where('cu.company_id', $companyId)
+            ->select('u.id', 'u.name', 'u.email', 'cu.role')
+            ->orderBy('u.name')
+            ->limit($limit)
+            ->get();
+    }
+
+    public function owners(string $companyId): Collection
+    {
+        return DB::table('auth.company_user as cu')
+            ->join('users as u', 'u.id', '=', 'cu.user_id')
+            ->where('cu.company_id', $companyId)
+            ->where('cu.role', 'owner')
+            ->select('u.id', 'u.name', 'u.email')
+            ->orderBy('u.name')
+            ->get();
+    }
+
+    public function roleCounts(string $companyId): Collection
+    {
+        return DB::table('auth.company_user')
+            ->select('role', DB::raw('count(*) as cnt'))
+            ->where('company_id', $companyId)
+            ->groupBy('role')
+            ->pluck('cnt', 'role');
+    }
+
+    public function countMembers(string $companyId): int
+    {
+        return DB::table('auth.company_user')
+            ->where('company_id', $companyId)
+            ->count();
+    }
+
+    public function searchMembers(string $companyId, string $q, int $limit = 10): Collection
+    {
+        $like = '%'.str_replace(['%', '_'], ['\\%', '\\_'], $q).'%';
+        return DB::table('auth.company_user as cu')
+            ->join('users as u', 'u.id', '=', 'cu.user_id')
+            ->where('cu.company_id', $companyId)
+            ->when($q !== '', function ($w) use ($like) {
+                $w->where(function ($q2) use ($like) {
+                    $q2->where('u.email', 'ilike', $like)
+                        ->orWhere('u.name', 'ilike', $like);
+                });
+            })
+            ->limit($limit)
+            ->get(['u.id', 'u.name', 'u.email', 'cu.role']);
+    }
+
+    public function userIdsForCompany(string $companyId): array
+    {
+        return DB::table('auth.company_user')
+            ->where('company_id', $companyId)
+            ->pluck('user_id')
+            ->all();
+    }
+
+    public function upsertMembership(string $companyId, string $userId, string $role, ?string $invitedByUserId = null, $now = null): void
+    {
+        $now = $now ?: now();
+        $exists = $this->verifyMembership($userId, $companyId);
+
+        if ($exists) {
+            DB::table('auth.company_user')
+                ->where('company_id', $companyId)
+                ->where('user_id', $userId)
+                ->update([
+                    'role' => $role,
+                    'invited_by_user_id' => $invitedByUserId,
+                    'updated_at' => $now,
+                ]);
+        } else {
+            DB::table('auth.company_user')->insert([
+                'company_id' => $companyId,
+                'user_id' => $userId,
+                'role' => $role,
+                'invited_by_user_id' => $invitedByUserId,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ]);
+        }
+    }
+}
+

--- a/app/app/Support/Tenancy.php
+++ b/app/app/Support/Tenancy.php
@@ -4,6 +4,7 @@ namespace App\Support;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
+use App\Repositories\CompanyMembershipRepository;
 
 class Tenancy
 {
@@ -17,10 +18,7 @@ class Tenancy
         $cid = self::currentCompanyId();
         if (! $cid) return null;
 
-        return DB::table('auth.company_user')
-            ->where('user_id', $userId)
-            ->where('company_id', $cid)
-            ->value('role');
+        return app(CompanyMembershipRepository::class)->roleForUser($userId, $cid);
     }
 
     public static function isMember(string $userId): bool
@@ -49,10 +47,7 @@ class Tenancy
 
     public static function verifyMembership(string $userId, string $companyId): bool
     {
-        return DB::table('auth.company_user')
-            ->where('user_id', $userId)
-            ->where('company_id', $companyId)
-            ->exists();
+        return app(CompanyMembershipRepository::class)->verifyMembership($userId, $companyId);
     }
 
     public static function applyDbSessionSettings($user, ?string $companyId = null): void
@@ -68,3 +63,4 @@ class Tenancy
         }
     }
 }
+

--- a/app/tests/Unit/CompanyMembershipRepositoryTest.php
+++ b/app/tests/Unit/CompanyMembershipRepositoryTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\User;
+use App\Models\Company;
+use App\Repositories\CompanyMembershipRepository;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CompanyMembershipRepositoryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_verify_membership_and_role_for_user(): void
+    {
+        $user = User::factory()->create();
+        $company = Company::factory()->create();
+        $user->companies()->attach($company->id, ['role' => 'admin']);
+
+        $repo = new CompanyMembershipRepository();
+
+        $this->assertTrue($repo->verifyMembership($user->id, $company->id));
+        $this->assertSame('admin', $repo->roleForUser($user->id, $company->id));
+        $this->assertFalse($repo->verifyMembership($user->id, \Ramsey\Uuid\Uuid::uuid4()->toString()));
+    }
+
+    public function test_memberships_returns_user_companies(): void
+    {
+        $user = User::factory()->create();
+        $c1 = Company::factory()->create(['name' => 'Acme']);
+        $c2 = Company::factory()->create(['name' => 'Beta']);
+        $user->companies()->attach($c1->id, ['role' => 'owner']);
+        $user->companies()->attach($c2->id, ['role' => 'viewer']);
+
+        $repo = new CompanyMembershipRepository();
+        $memberships = $repo->memberships($user->id);
+
+        $this->assertCount(2, $memberships);
+        $this->assertEqualsCanonicalizing([
+            $c1->id,
+            $c2->id,
+        ], $memberships->pluck('id')->all());
+    }
+}
+


### PR DESCRIPTION
## Summary
- encapsulate common membership queries in `CompanyMembershipRepository`
- refactor controllers and services to use repository instead of direct DB table access
- add unit tests for membership repository

## Testing
- `php artisan test --testsuite=Unit` *(fails: connection to server at "127.0.0.1", port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b93ae041508322aa299b3bfccce79a