### PR TITLE
Add comprehensive invitation and lookup tests

### DIFF
--- a/app/app/Services/LookupService.php
+++ b/app/app/Services/LookupService.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Company;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+class LookupService
+{
+    /**
+     * Lookup companies applying membership and query filters.
+     */
+    public function companies(User $user, string $q = '', int $limit = 10, array $filters = [])
+    {
+        $query = Company::query()->select(['id','name','slug','base_currency','language','locale']);
+
+        if ($q !== '') {
+            $like = '%'.str_replace(['%','_'], ['\\%','\\_'], $q).'%';
+            $query->where(function ($w) use ($like) {
+                $w->where('name', 'ilike', $like)
+                  ->orWhere('slug', 'ilike', $like);
+            });
+        }
+
+        if (! $user->isSuperAdmin()) {
+            $query->whereIn('id', function ($sub) use ($user) {
+                $sub->from('auth.company_user')->select('company_id')->where('user_id', $user->id);
+            });
+        }
+
+        if (($filters['user_id'] ?? null || $filters['user_email'] ?? null) && $user->isSuperAdmin()) {
+            $query->whereIn('id', function ($sub) use ($filters) {
+                $sub->from('auth.company_user')->select('company_id')
+                    ->when($filters['user_id'] ?? null, fn($w, $uid) => $w->where('user_id', $uid))
+                    ->when($filters['user_email'] ?? null, function ($w, $email) {
+                        $uid = DB::table('users')->where('email', $email)->value('id');
+                        if ($uid) {
+                            $w->where('user_id', $uid);
+                        }
+                    });
+            });
+        }
+
+        return $query->limit($limit)->get();
+    }
+}

--- a/app/database/factories/CompanyInvitationFactory.php
+++ b/app/database/factories/CompanyInvitationFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\CompanyInvitation;
+use App\Models\Company;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class CompanyInvitationFactory extends Factory
+{
+    protected $model = CompanyInvitation::class;
+
+    public function definition(): array
+    {
+        return [
+            'company_id' => Company::factory(),
+            'invited_email' => $this->faker->unique()->safeEmail(),
+            'role' => 'member',
+            'invited_by_user_id' => User::factory(),
+            'token' => Str::random(40),
+            'status' => 'pending',
+            'expires_at' => null,
+        ];
+    }
+}

--- a/app/tests/Feature/CompanyLookupControllerTest.php
+++ b/app/tests/Feature/CompanyLookupControllerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Company;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CompanyLookupControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_sees_only_their_companies(): void
+    {
+        $user = User::factory()->create();
+        $companyA = Company::factory()->create(['name' => 'Alpha Corp']);
+        $companyB = Company::factory()->create(['name' => 'Beta LLC']);
+        $user->companies()->attach($companyA->id, ['role' => 'member']);
+
+        $this->actingAs($user);
+        $res = $this->getJson('/api/v1/companies');
+        $res->assertOk();
+        $res->assertJsonCount(1, 'data');
+        $res->assertJsonFragment(['name' => 'Alpha Corp']);
+    }
+
+    public function test_superadmin_can_filter_by_query_and_user_email(): void
+    {
+        $super = User::factory()->create(['system_role' => 'superadmin']);
+        $user = User::factory()->create();
+        $companyA = Company::factory()->create(['name' => 'Acme Widgets']);
+        $companyB = Company::factory()->create(['name' => 'Beta Stuff']);
+        $user->companies()->attach($companyB->id, ['role' => 'member']);
+
+        $this->actingAs($super);
+        $res = $this->getJson('/api/v1/companies?q=Acme');
+        $res->assertOk();
+        $res->assertJsonCount(1, 'data');
+        $res->assertJsonFragment(['name' => 'Acme Widgets']);
+
+        $res = $this->getJson('/api/v1/companies?user_email='.$user->email);
+        $res->assertOk();
+        $res->assertJsonCount(1, 'data');
+        $res->assertJsonFragment(['name' => 'Beta Stuff']);
+    }
+
+    public function test_non_member_cannot_access_company_users(): void
+    {
+        $user = User::factory()->create();
+        $other = User::factory()->create();
+        $company = Company::factory()->create();
+        $other->companies()->attach($company->id, ['role' => 'member']);
+
+        $this->actingAs($user);
+        $this->getJson('/api/v1/companies/'.$company->id.'/users')
+            ->assertStatus(403);
+    }
+
+    public function test_member_can_filter_company_users(): void
+    {
+        $user = User::factory()->create();
+        $other = User::factory()->create(['name' => 'Zed Person', 'email' => 'zed@example.com']);
+        $company = Company::factory()->create();
+        $user->companies()->attach($company->id, ['role' => 'admin']);
+        $other->companies()->attach($company->id, ['role' => 'member']);
+
+        $this->actingAs($user);
+        $res = $this->getJson('/api/v1/companies/'.$company->id.'/users?q=zed');
+        $res->assertOk();
+        $res->assertJsonCount(1, 'data');
+        $res->assertJsonFragment(['email' => 'zed@example.com']);
+    }
+}

--- a/app/tests/Feature/InvitationServiceTest.php
+++ b/app/tests/Feature/InvitationServiceTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Company;
+use App\Models\CompanyInvitation;
+use App\Models\User;
+use App\Services\InvitationService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+use Tests\TestCase;
+
+class InvitationServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected InvitationService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->service = new InvitationService();
+    }
+
+    public function test_owner_can_list_company_invitations(): void
+    {
+        $owner = User::factory()->create();
+        $company = Company::factory()->create();
+        $owner->companies()->attach($company->id, ['role' => 'owner']);
+
+        CompanyInvitation::factory()->count(2)->create([
+            'company_id' => $company->id,
+        ]);
+
+        $list = $this->service->listCompanyInvitations($owner, $company->id);
+        $this->assertCount(2, $list);
+    }
+
+    public function test_viewer_cannot_list_company_invitations(): void
+    {
+        $viewer = User::factory()->create();
+        $company = Company::factory()->create();
+        $viewer->companies()->attach($company->id, ['role' => 'viewer']);
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionCode(403);
+        $this->service->listCompanyInvitations($viewer, $company->id);
+    }
+
+    public function test_user_can_accept_their_invitation(): void
+    {
+        $user = User::factory()->create();
+        $company = Company::factory()->create();
+        $inv = CompanyInvitation::factory()->create([
+            'company_id' => $company->id,
+            'invited_email' => $user->email,
+            'role' => 'admin',
+        ]);
+
+        $companyId = $this->service->accept($user, $inv->token);
+
+        $this->assertEquals($company->id, $companyId);
+        $this->assertDatabaseHas('auth.company_user', [
+            'company_id' => $company->id,
+            'user_id' => $user->id,
+            'role' => 'admin',
+        ]);
+        $this->assertDatabaseHas('auth.company_invitations', [
+            'id' => $inv->id,
+            'status' => 'accepted',
+        ]);
+    }
+
+    public function test_other_user_cannot_accept_invitation(): void
+    {
+        $user = User::factory()->create();
+        $other = User::factory()->create();
+        $company = Company::factory()->create();
+        $inv = CompanyInvitation::factory()->create([
+            'company_id' => $company->id,
+            'invited_email' => $user->email,
+        ]);
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionCode(403);
+        $this->service->accept($other, $inv->token);
+    }
+
+    public function test_admin_can_revoke_invitation(): void
+    {
+        $admin = User::factory()->create();
+        $company = Company::factory()->create();
+        $admin->companies()->attach($company->id, ['role' => 'admin']);
+        $inv = CompanyInvitation::factory()->create([
+            'company_id' => $company->id,
+            'invited_by_user_id' => $admin->id,
+        ]);
+
+        $this->service->revoke($admin, $inv->id);
+
+        $this->assertDatabaseHas('auth.company_invitations', [
+            'id' => $inv->id,
+            'status' => 'revoked',
+        ]);
+    }
+
+    public function test_unauthorized_user_cannot_revoke_invitation(): void
+    {
+        $admin = User::factory()->create();
+        $other = User::factory()->create();
+        $company = Company::factory()->create();
+        $admin->companies()->attach($company->id, ['role' => 'admin']);
+        $inv = CompanyInvitation::factory()->create([
+            'company_id' => $company->id,
+            'invited_by_user_id' => $admin->id,
+        ]);
+
+        $this->expectException(HttpException::class);
+        $this->expectExceptionCode(403);
+        $this->service->revoke($other, $inv->id);
+    }
+}

--- a/app/tests/Feature/LookupServiceTest.php
+++ b/app/tests/Feature/LookupServiceTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Company;
+use App\Models\User;
+use App\Services\LookupService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class LookupServiceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_service_respects_membership(): void
+    {
+        $user = User::factory()->create();
+        $companyA = Company::factory()->create(['name' => 'Alpha']);
+        $companyB = Company::factory()->create(['name' => 'Beta']);
+        $user->companies()->attach($companyA->id, ['role' => 'member']);
+
+        $service = new LookupService();
+        $results = $service->companies($user);
+
+        $this->assertCount(1, $results);
+        $this->assertEquals($companyA->id, $results[0]->id);
+    }
+
+    public function test_service_allows_superadmin_to_filter_by_query(): void
+    {
+        $super = User::factory()->create(['system_role' => 'superadmin']);
+        Company::factory()->create(['name' => 'Acme Co']);
+        Company::factory()->create(['name' => 'Beta Co']);
+
+        $service = new LookupService();
+        $results = $service->companies($super, 'Acme');
+
+        $this->assertCount(1, $results);
+        $this->assertEquals('Acme Co', $results[0]->name);
+    }
+
+    public function test_service_filters_by_user_email_for_superadmin(): void
+    {
+        $super = User::factory()->create(['system_role' => 'superadmin']);
+        $member = User::factory()->create();
+        $company = Company::factory()->create(['name' => 'Gamma']);
+        $member->companies()->attach($company->id, ['role' => 'member']);
+
+        $service = new LookupService();
+        $results = $service->companies($super, '', 10, ['user_email' => $member->email]);
+
+        $this->assertCount(1, $results);
+        $this->assertEquals('Gamma', $results[0]->name);
+    }
+}


### PR DESCRIPTION
## Summary
- add company invitation factory and lookup service
- cover listing, acceptance, and revocation in InvitationService tests
- test CompanyLookupController and generic LookupService behaviors

## Testing
- `php artisan test` *(fails: connection to server at "127.0.0.1", port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b93c4887d08322b66ce1537cca53a5