### PR TITLE
Refactor company admin view into modular components

### DIFF
--- a/app/resources/js/Pages/Admin/Companies/CompanyInviteSection.vue
+++ b/app/resources/js/Pages/Admin/Companies/CompanyInviteSection.vue
@@ -1,0 +1,97 @@
+<script setup>
+import InputLabel from '@/Components/InputLabel.vue'
+import TextInput from '@/Components/TextInput.vue'
+import PrimaryButton from '@/Components/PrimaryButton.vue'
+import SecondaryButton from '@/Components/SecondaryButton.vue'
+import Collapsible from '@/Components/Collapsible.vue'
+import { onMounted, computed } from 'vue'
+import { useCompanyInvites } from '@/composables/useCompanyInvites.js'
+
+const props = defineProps({
+  company: { type: String, required: true }
+})
+
+const {
+  invite,
+  inviteLoading,
+  inviteError,
+  inviteOk,
+  invites,
+  invitesLoading,
+  invitesError,
+  revokeId,
+  sendInvite,
+  revokeInvite,
+  loadInvites,
+} = useCompanyInvites(computed(() => props.company))
+
+onMounted(loadInvites)
+</script>
+
+<template>
+  <div class="overflow-hidden bg-white shadow sm:rounded-md p-6">
+    <div class="font-medium mb-3">Invite by Email</div>
+    <div class="grid grid-cols-1 md:grid-cols-4 gap-3 items-end">
+      <div class="md:col-span-2">
+        <InputLabel value="Email" />
+        <TextInput v-model="invite.email" class="mt-1 block w-full" placeholder="invitee@example.com" />
+      </div>
+      <div>
+        <InputLabel value="Role" />
+        <select v-model="invite.role" class="mt-1 block w-full rounded border-gray-300">
+          <option value="owner">Owner</option>
+          <option value="admin">Admin</option>
+          <option value="accountant">Accountant</option>
+          <option value="viewer">Viewer</option>
+        </select>
+      </div>
+      <div>
+        <InputLabel value="Expires in days" />
+        <TextInput v-model="invite.expires_in_days" class="mt-1 block w-full" placeholder="14" />
+      </div>
+    </div>
+    <div class="mt-3">
+      <PrimaryButton @click="sendInvite" :disabled="inviteLoading">Send Invitation</PrimaryButton>
+      <span v-if="inviteLoading" class="ms-2 text-sm text-gray-500">Sending…</span>
+    </div>
+    <div v-if="inviteError" class="mt-3 rounded border border-red-200 bg-red-50 p-2 text-xs text-red-700">{{ inviteError }}</div>
+    <div v-if="inviteOk" class="mt-3 rounded border border-green-200 bg-green-50 p-2 text-xs text-green-700">
+      Invitation created for <b>{{ inviteOk.email }}</b> (role: {{ inviteOk.role }}) · id: <code>{{ inviteOk.id }}</code>
+      <div class="mt-1">Token (dev only): <code class="break-all">{{ inviteOk.token }}</code></div>
+      <div class="mt-2 flex items-center gap-2">
+        <TextInput v-model="revokeId" placeholder="Paste invitation id to revoke" class="w-72" />
+        <SecondaryButton @click="revokeInvite(inviteOk.id)">Revoke this invite</SecondaryButton>
+        <SecondaryButton @click="revokeInvite()">Revoke by id</SecondaryButton>
+      </div>
+    </div>
+
+    <div class="mt-6">
+      <Collapsible :defaultOpen="true">
+        <template #trigger>
+          <button class="flex w-full items-center justify-between rounded bg-gray-50 px-3 py-2 text-left text-sm font-medium text-gray-700 hover:bg-gray-100">
+            <span>Pending Invitations</span>
+            <span class="text-xs text-gray-500">(click to toggle)</span>
+          </button>
+        </template>
+        <div class="pt-2">
+          <div v-if="invitesLoading" class="text-sm text-gray-500">Loading…</div>
+          <div v-else-if="invitesError" class="text-sm text-red-600">{{ invitesError }}</div>
+          <div v-else>
+            <ul class="divide-y divide-gray-200">
+              <li v-for="i in invites" :key="i.id" class="py-3 flex items-center justify-between">
+                <div>
+                  <div class="text-sm font-medium text-gray-900">{{ i.email }}</div>
+                  <div class="text-xs text-gray-500">role: {{ i.role }} · invited by: {{ i.invited_by || '—' }} · expires: {{ i.expires_at || '—' }}</div>
+                </div>
+                <div>
+                  <SecondaryButton @click="revokeInvite(i.id)">Revoke</SecondaryButton>
+                </div>
+              </li>
+              <li v-if="(invites || []).length === 0" class="py-3 text-sm text-gray-500">No pending invitations.</li>
+            </ul>
+          </div>
+        </div>
+      </Collapsible>
+    </div>
+  </div>
+</template>

--- a/app/resources/js/Pages/Admin/Companies/CompanyMembersSection.vue
+++ b/app/resources/js/Pages/Admin/Companies/CompanyMembersSection.vue
@@ -1,0 +1,65 @@
+<script setup>
+import InputLabel from '@/Components/InputLabel.vue'
+import PrimaryButton from '@/Components/PrimaryButton.vue'
+import UserPicker from '@/Components/Pickers/UserPicker.vue'
+import CompanyMemberList from '@/Components/CompanyMemberList.vue'
+import { onMounted, computed } from 'vue'
+import { useCompanyMembers } from '@/composables/useCompanyMembers.js'
+
+const props = defineProps({
+  company: { type: String, required: true }
+})
+
+const {
+  members,
+  loading,
+  error,
+  q,
+  roleOptions,
+  assign,
+  assignLoading,
+  assignError,
+  loadMembers,
+  assignUser,
+  updateRole,
+  unassign,
+} = useCompanyMembers(computed(() => props.company))
+
+onMounted(loadMembers)
+</script>
+
+<template>
+  <div class="space-y-4">
+    <div v-if="error" class="rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">{{ error }}</div>
+
+    <div class="overflow-hidden bg-white shadow sm:rounded-md p-6">
+      <div class="font-medium mb-3">Assign Existing User</div>
+      <div class="grid grid-cols-1 md:grid-cols-3 gap-3 items-end">
+        <div>
+          <InputLabel value="User" />
+          <UserPicker v-model="assign.email" class="mt-1 block w-full" placeholder="Find user by name or email…" />
+        </div>
+        <div>
+          <InputLabel value="Role" />
+          <select v-model="assign.role" class="mt-1 block w-full rounded border-gray-300">
+            <option v-for="r in roleOptions" :key="r.value" :value="r.value">{{ r.label }}</option>
+          </select>
+        </div>
+        <div>
+          <PrimaryButton @click="assignUser" :disabled="assignLoading">Assign</PrimaryButton>
+          <span v-if="assignLoading" class="ms-2 text-sm text-gray-500">Assigning…</span>
+        </div>
+      </div>
+      <div v-if="assignError" class="mt-3 rounded border border-red-200 bg-red-50 p-2 text-xs text-red-700">{{ assignError }}</div>
+    </div>
+
+    <CompanyMemberList
+      :members="members"
+      :loading="loading"
+      :role-options="roleOptions"
+      v-model:query="q"
+      @update-role="updateRole"
+      @unassign="unassign"
+    />
+  </div>
+</template>

--- a/app/resources/js/Pages/Admin/Companies/CompanyOverview.vue
+++ b/app/resources/js/Pages/Admin/Companies/CompanyOverview.vue
@@ -1,0 +1,17 @@
+<script setup>
+const props = defineProps({
+  company: { type: Object, default: null }
+})
+</script>
+
+<template>
+  <div class="overflow-hidden bg-white shadow sm:rounded-md p-6">
+    <div class="text-lg font-semibold">{{ company?.name || '—' }}</div>
+    <div class="text-xs text-gray-500 mt-1">Slug: {{ company?.slug }}</div>
+    <div class="mt-3 text-sm text-gray-700">
+      <div><span class="text-gray-500">Currency:</span> {{ company?.base_currency }}</div>
+      <div><span class="text-gray-500">Language:</span> {{ company?.language }}</div>
+      <div><span class="text-gray-500">Locale:</span> {{ company?.locale }}</div>
+    </div>
+  </div>
+</template>

--- a/app/resources/js/Pages/Admin/Companies/Show.vue
+++ b/app/resources/js/Pages/Admin/Companies/Show.vue
@@ -1,34 +1,18 @@
 <script setup>
 import AuthenticatedLayout from '@/Layouts/AuthenticatedLayout.vue'
 import { Head, Link } from '@inertiajs/vue3'
-import { ref, onMounted, watch, computed } from 'vue'
-import InputLabel from '@/Components/InputLabel.vue'
-import TextInput from '@/Components/TextInput.vue'
-import PrimaryButton from '@/Components/PrimaryButton.vue'
-import SecondaryButton from '@/Components/SecondaryButton.vue'
-import UserPicker from '@/Components/Pickers/UserPicker.vue'
-import Collapsible from '@/Components/Collapsible.vue'
-import CompanyMemberList from '@/Components/CompanyMemberList.vue'
-import { http, withIdempotency } from '@/lib/http';
-import { TabsRoot as Tabs, TabsList, TabsTrigger, TabsContent } from 'reka-ui';
-import { useToasts } from '@/composables/useToasts.js'
+import { ref, onMounted, computed } from 'vue'
+import { TabsRoot as Tabs, TabsList, TabsTrigger, TabsContent } from 'reka-ui'
+import { http } from '@/lib/http'
 import { usePersistentTabs } from '@/composables/usePersistentTabs.js'
+import CompanyMembersSection from './CompanyMembersSection.vue'
+import CompanyInviteSection from './CompanyInviteSection.vue'
+import CompanyOverview from './CompanyOverview.vue'
 
 const props = defineProps({ company: { type: String, required: true } })
-const { addToast } = useToasts()
 
 const c = ref(null)
-const members = ref([])
-const loading = ref(false)
 const error = ref('')
-const q = ref('')
-
-const roleOptions = [
-  { value: 'owner', label: 'Owner' },
-  { value: 'admin', label: 'Admin' },
-  { value: 'accountant', label: 'Accountant' },
-  { value: 'viewer', label: 'Viewer' },
-]
 
 async function loadCompany() {
   try {
@@ -39,156 +23,18 @@ async function loadCompany() {
   }
 }
 
-async function loadMembers() {
-  loading.value = true
-  try {
-    const { data } = await http.get(`/web/companies/${encodeURIComponent(props.company)}/users`, { params: { q: q.value, limit: 100 } })
-    // map to allow local edits of role select
-    members.value = (data.data || []).map(m => ({ ...m }))
-  } catch (e) {
-    error.value = e?.response?.data?.message || 'Failed to load members'
-  } finally {
-    loading.value = false
-  }
-}
+onMounted(loadCompany)
 
-onMounted(async () => {
-  await loadCompany()
-  await loadMembers()
-  await loadInvites()
-})
-watch(q, () => { const t = setTimeout(loadMembers, 250); return () => clearTimeout(t) })
+const slug = computed(() => c.value?.slug || props.company)
 
-// Assign existing user to this company
-const assign = ref({ email: '', role: 'viewer' })
-const assignLoading = ref(false)
-const assignError = ref('')
-
-async function assignUser() {
-  if (!assign.value.email || !assign.value.role) return
-  assignLoading.value = true
-  assignError.value = ''
-  try {
-    const { data } = await http.post('/commands', {
-      email: assign.value.email,
-      company: c.value?.slug || props.company,
-      role: assign.value.role,
-    }, { headers: withIdempotency({ 'X-Action': 'company.assign' }) })
-    members.value.unshift(data.data) // Add new member to the top of the list
-    assign.value.email = '' // Reset form
-    assign.value.role = 'viewer'
-    addToast('User assigned successfully.', 'success')
-  } catch (e) {
-    const message = e?.response?.data?.message || 'Failed to assign user'
-    assignError.value = message
-    addToast(message, 'danger')
-  } finally {
-    assignLoading.value = false
-  }
-}
-
-async function updateRole(m) {
-  const originalRole = members.value.find(mem => mem.id === m.id)?.role
-  if (originalRole === m.role) return; // No change
-  try {
-    const { data } = await http.post('/commands', {
-      email: m.email,
-      company: c.value?.slug || props.company,
-      role: m.role,
-    }, { headers: withIdempotency({ 'X-Action': 'company.assign' }) })
-    const index = members.value.findIndex(mem => mem.id === m.id)
-    if (index !== -1) members.value.splice(index, 1, data.data)
-    addToast('Role updated successfully.', 'success')
-  } catch (e) {
-    m.role = originalRole // Revert UI on failure
-    addToast(e?.response?.data?.message || 'Failed to update role', 'danger')
-  }
-}
-
-async function unassign(m) {
-  if (!confirm(`Remove ${m.email} from ${c.value?.name || props.company}?`)) return
-  try {
-    await http.post('/commands', {
-      email: m.email,
-      company: c.value?.slug || props.company,
-    }, { headers: withIdempotency({ 'X-Action': 'company.unassign' }) })
-    members.value = members.value.filter(mem => mem.id !== m.id)
-    addToast('User removed successfully.', 'success')
-  } catch (e) {
-    addToast(e?.response?.data?.message || 'Failed to remove user', 'danger')
-  }
-}
-
-// Invitations
-const invite = ref({ email: '', role: 'viewer', expires_in_days: 14 })
-const inviteLoading = ref(false)
-const inviteError = ref('')
-const inviteOk = ref(null) // last invite created (dev purposes)
-const invites = ref([])
-const invitesLoading = ref(false)
-const invitesError = ref('')
-
-async function sendInvite() {
-  inviteLoading.value = true
-  inviteError.value = ''
-  inviteOk.value = null
-  try {
-    const { data } = await http.post('/commands', {
-      ...invite.value,
-      company: c.value?.slug || props.company,
-    }, { headers: withIdempotency({ 'X-Action': 'company.invite' }) })
-    inviteOk.value = data.data
-    invites.value.unshift(data.data)
-    invite.value.email = ''
-    addToast('Invitation sent successfully.', 'success')
-  } catch (e) {
-    const message = e?.response?.data?.message || 'Failed to create invitation'
-    inviteError.value = message
-    addToast(message, 'danger')
-  } finally {
-    inviteLoading.value = false
-  }
-}
-
-const revokeId = ref('')
-async function revokeInvite(id) {
-  const target = id || revokeId.value
-  if (!target) return
-  try {
-    await http.post('/commands', {
-      id: target,
-    }, { headers: withIdempotency({ 'X-Action': 'invitation.revoke' }) })
-    if (inviteOk.value && inviteOk.value.id === target) inviteOk.value.status = 'revoked'
-    revokeId.value = ''
-    invites.value = invites.value.filter(i => i.id !== target)
-    addToast('Invitation revoked.', 'success')
-  } catch (e) {
-    addToast(e?.response?.data?.message || 'Failed to revoke invitation', 'danger')
-  }
-}
-
-const tabNames = ['members', 'assign', 'invite']
-const storageKey = computed(() => `admin.company.tab.${c.value?.slug || props.company}`)
+const tabNames = ['members', 'invite']
+const storageKey = computed(() => `admin.company.tab.${slug.value}`)
 const { selectedTab } = usePersistentTabs(tabNames, storageKey)
 const tabValue = computed({
   get: () => String(selectedTab.value),
   set: (val) => { selectedTab.value = Number(val) }
 })
-
-async function loadInvites() {
-  invitesLoading.value = true
-  invitesError.value = ''
-  try {
-    const target = encodeURIComponent(c.value?.slug || props.company)
-    const { data } = await http.get(`/web/companies/${target}/invitations`, { params: { status: 'pending' } })
-    invites.value = data.data || []
-  } catch (e) {
-    invitesError.value = e?.response?.data?.message || 'Failed to load invitations'
-  } finally {
-    invitesLoading.value = false
-  }
-}
-  </script>
+</script>
 
 <template>
   <Head :title="c ? `Company · ${c.name}` : 'Company'" />
@@ -205,20 +51,10 @@ async function loadInvites() {
         <div v-if="error" class="mb-4 rounded border border-red-200 bg-red-50 p-3 text-sm text-red-700">{{ error }}</div>
 
         <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <!-- Company summary -->
           <div class="lg:col-span-1">
-            <div class="overflow-hidden bg-white shadow sm:rounded-md p-6">
-              <div class="text-lg font-semibold">{{ c?.name || '—' }}</div>
-              <div class="text-xs text-gray-500 mt-1">Slug: {{ c?.slug }}</div>
-              <div class="mt-3 text-sm text-gray-700">
-                <div><span class="text-gray-500">Currency:</span> {{ c?.base_currency }}</div>
-                <div><span class="text-gray-500">Language:</span> {{ c?.language }}</div>
-                <div><span class="text-gray-500">Locale:</span> {{ c?.locale }}</div>
-              </div>
-            </div>
+            <CompanyOverview :company="c" />
           </div>
 
-          <!-- Members / Assign / Invite as tabs -->
           <div class="lg:col-span-2">
             <Tabs v-model="tabValue" class="w-full">
               <div class="sticky top-16 z-10 bg-white/80 backdrop-blur supports-[backdrop-filter]:bg-white/60">
@@ -227,114 +63,16 @@ async function loadInvites() {
                     Members
                   </TabsTrigger>
                   <TabsTrigger value="1" class="focus:outline-none px-4 py-2 text-sm data-[state=active]:border-b-2 data-[state=active]:border-indigo-600 data-[state=active]:text-indigo-600 text-gray-600 hover:text-gray-800">
-                    Assign
-                  </TabsTrigger>
-                  <TabsTrigger value="2" class="focus:outline-none px-4 py-2 text-sm data-[state=active]:border-b-2 data-[state=active]:border-indigo-600 data-[state=active]:text-indigo-600 text-gray-600 hover:text-gray-800">
                     Invite
                   </TabsTrigger>
                 </TabsList>
               </div>
               <div class="mt-4">
-                <!-- Members Tab -->
                 <TabsContent value="0">
-                  <CompanyMemberList
-                    :members="members"
-                    :loading="loading"
-                    :role-options="roleOptions"
-                    v-model:query="q"
-                    @update-role="updateRole"
-                    @unassign="unassign"
-                  />
+                  <CompanyMembersSection :company="slug" />
                 </TabsContent>
-
-                <!-- Assign Tab -->
                 <TabsContent value="1">
-                  <div class="overflow-hidden bg-white shadow sm:rounded-md p-6">
-                    <div class="font-medium mb-3">Assign Existing User</div>
-                    <div class="grid grid-cols-1 md:grid-cols-3 gap-3 items-end">
-                      <div>
-                        <InputLabel value="User" />
-                        <UserPicker v-model="assign.email" class="mt-1 block w-full" placeholder="Find user by name or email…" />
-                      </div>
-                      <div>
-                        <InputLabel value="Role" />
-                        <select v-model="assign.role" class="mt-1 block w-full rounded border-gray-300">
-                          <option v-for="r in roleOptions" :key="r.value" :value="r.value">{{ r.label }}</option>
-                        </select>
-                      </div>
-                      <div>
-                        <PrimaryButton @click="assignUser" :disabled="assignLoading">Assign</PrimaryButton>
-                        <span v-if="assignLoading" class="ms-2 text-sm text-gray-500">Assigning…</span>
-                      </div>
-                    </div>
-                    <div v-if="assignError" class="mt-3 rounded border border-red-200 bg-red-50 p-2 text-xs text-red-700">{{ assignError }}</div>
-                  </div>
-                </TabsContent>
-
-                <!-- Invite Tab -->
-                <TabsContent value="2">
-                  <div class="overflow-hidden bg-white shadow sm:rounded-md p-6">
-                    <div class="font-medium mb-3">Invite by Email</div>
-                    <div class="grid grid-cols-1 md:grid-cols-4 gap-3 items-end">
-                      <div class="md:col-span-2">
-                        <InputLabel value="Email" />
-                        <TextInput v-model="invite.email" class="mt-1 block w-full" placeholder="invitee@example.com" />
-                      </div>
-                      <div>
-                        <InputLabel value="Role" />
-                        <select v-model="invite.role" class="mt-1 block w-full rounded border-gray-300">
-                          <option v-for="r in roleOptions" :key="r.value" :value="r.value">{{ r.label }}</option>
-                        </select>
-                      </div>
-                      <div>
-                        <InputLabel value="Expires in days" />
-                        <TextInput v-model="invite.expires_in_days" class="mt-1 block w-full" placeholder="14" />
-                      </div>
-                    </div>
-                    <div class="mt-3">
-                      <PrimaryButton @click="sendInvite" :disabled="inviteLoading">Send Invitation</PrimaryButton>
-                      <span v-if="inviteLoading" class="ms-2 text-sm text-gray-500">Sending…</span>
-                    </div>
-                    <div v-if="inviteError" class="mt-3 rounded border border-red-200 bg-red-50 p-2 text-xs text-red-700">{{ inviteError }}</div>
-                    <div v-if="inviteOk" class="mt-3 rounded border border-green-200 bg-green-50 p-2 text-xs text-green-700">
-                      Invitation created for <b>{{ inviteOk.email }}</b> (role: {{ inviteOk.role }}) · id: <code>{{ inviteOk.id }}</code>
-                      <div class="mt-1">Token (dev only): <code class="break-all">{{ inviteOk.token }}</code></div>
-                      <div class="mt-2 flex items-center gap-2">
-                        <TextInput v-model="revokeId" placeholder="Paste invitation id to revoke" class="w-72" />
-                        <SecondaryButton @click="revokeInvite(inviteOk.id)">Revoke this invite</SecondaryButton>
-                        <SecondaryButton @click="revokeInvite()">Revoke by id</SecondaryButton>
-                      </div>
-                    </div>
-
-                    <div class="mt-6">
-                      <Collapsible :defaultOpen="true">
-                        <template #trigger>
-                          <button class="flex w-full items-center justify-between rounded bg-gray-50 px-3 py-2 text-left text-sm font-medium text-gray-700 hover:bg-gray-100">
-                            <span>Pending Invitations</span>
-                            <span class="text-xs text-gray-500">(click to toggle)</span>
-                          </button>
-                        </template>
-                        <div class="pt-2">
-                          <div v-if="invitesLoading" class="text-sm text-gray-500">Loading…</div>
-                          <div v-else-if="invitesError" class="text-sm text-red-600">{{ invitesError }}</div>
-                          <div v-else>
-                            <ul class="divide-y divide-gray-200">
-                              <li v-for="i in invites" :key="i.id" class="py-3 flex items-center justify-between">
-                                <div>
-                                  <div class="text-sm font-medium text-gray-900">{{ i.email }}</div>
-                                  <div class="text-xs text-gray-500">role: {{ i.role }} · invited by: {{ i.invited_by || '—' }} · expires: {{ i.expires_at || '—' }}</div>
-                                </div>
-                                <div>
-                                  <SecondaryButton @click="revokeInvite(i.id)">Revoke</SecondaryButton>
-                                </div>
-                              </li>
-                              <li v-if="(invites || []).length === 0" class="py-3 text-sm text-gray-500">No pending invitations.</li>
-                            </ul>
-                            </div>
-                          </div>
-                      </Collapsible>
-                    </div>
-                  </div>
+                  <CompanyInviteSection :company="slug" />
                 </TabsContent>
               </div>
             </Tabs>

--- a/app/resources/js/composables/useCompanyInvites.js
+++ b/app/resources/js/composables/useCompanyInvites.js
@@ -1,0 +1,85 @@
+import { ref, unref } from 'vue'
+import { http, withIdempotency } from '@/lib/http'
+import { useToasts } from './useToasts.js'
+
+export function useCompanyInvites(company) {
+  const invite = ref({ email: '', role: 'viewer', expires_in_days: 14 })
+  const inviteLoading = ref(false)
+  const inviteError = ref('')
+  const inviteOk = ref(null)
+
+  const invites = ref([])
+  const invitesLoading = ref(false)
+  const invitesError = ref('')
+
+  const revokeId = ref('')
+
+  const { addToast } = useToasts()
+
+  const companySlug = () => encodeURIComponent(unref(company))
+
+  async function sendInvite() {
+    inviteLoading.value = true
+    inviteError.value = ''
+    inviteOk.value = null
+    try {
+      const { data } = await http.post('/commands', {
+        ...invite.value,
+        company: unref(company),
+      }, { headers: withIdempotency({ 'X-Action': 'company.invite' }) })
+      inviteOk.value = data.data
+      invites.value.unshift(data.data)
+      invite.value.email = ''
+      addToast('Invitation sent successfully.', 'success')
+    } catch (e) {
+      const message = e?.response?.data?.message || 'Failed to create invitation'
+      inviteError.value = message
+      addToast(message, 'danger')
+    } finally {
+      inviteLoading.value = false
+    }
+  }
+
+  async function revokeInvite(id) {
+    const target = id || revokeId.value
+    if (!target) return
+    try {
+      await http.post('/commands', {
+        id: target,
+      }, { headers: withIdempotency({ 'X-Action': 'invitation.revoke' }) })
+      if (inviteOk.value && inviteOk.value.id === target) inviteOk.value.status = 'revoked'
+      revokeId.value = ''
+      invites.value = invites.value.filter(i => i.id !== target)
+      addToast('Invitation revoked.', 'success')
+    } catch (e) {
+      addToast(e?.response?.data?.message || 'Failed to revoke invitation', 'danger')
+    }
+  }
+
+  async function loadInvites() {
+    invitesLoading.value = true
+    invitesError.value = ''
+    try {
+      const { data } = await http.get(`/web/companies/${companySlug()}/invitations`, { params: { status: 'pending' } })
+      invites.value = data.data || []
+    } catch (e) {
+      invitesError.value = e?.response?.data?.message || 'Failed to load invitations'
+    } finally {
+      invitesLoading.value = false
+    }
+  }
+
+  return {
+    invite,
+    inviteLoading,
+    inviteError,
+    inviteOk,
+    invites,
+    invitesLoading,
+    invitesError,
+    revokeId,
+    sendInvite,
+    revokeInvite,
+    loadInvites,
+  }
+}

--- a/app/resources/js/composables/useCompanyMembers.js
+++ b/app/resources/js/composables/useCompanyMembers.js
@@ -1,0 +1,110 @@
+import { ref, watch, unref } from 'vue'
+import { http, withIdempotency } from '@/lib/http'
+import { useToasts } from './useToasts.js'
+
+const roleOptions = [
+  { value: 'owner', label: 'Owner' },
+  { value: 'admin', label: 'Admin' },
+  { value: 'accountant', label: 'Accountant' },
+  { value: 'viewer', label: 'Viewer' },
+]
+
+export function useCompanyMembers(company) {
+  const members = ref([])
+  const loading = ref(false)
+  const error = ref('')
+  const q = ref('')
+
+  const assign = ref({ email: '', role: 'viewer' })
+  const assignLoading = ref(false)
+  const assignError = ref('')
+
+  const { addToast } = useToasts()
+
+  const companySlug = () => encodeURIComponent(unref(company))
+
+  async function loadMembers() {
+    loading.value = true
+    error.value = ''
+    try {
+      const { data } = await http.get(`/web/companies/${companySlug()}/users`, { params: { q: q.value, limit: 100 } })
+      members.value = (data.data || []).map(m => ({ ...m }))
+    } catch (e) {
+      error.value = e?.response?.data?.message || 'Failed to load members'
+    } finally {
+      loading.value = false
+    }
+  }
+
+  async function assignUser() {
+    if (!assign.value.email || !assign.value.role) return
+    assignLoading.value = true
+    assignError.value = ''
+    try {
+      const { data } = await http.post('/commands', {
+        email: assign.value.email,
+        company: unref(company),
+        role: assign.value.role,
+      }, { headers: withIdempotency({ 'X-Action': 'company.assign' }) })
+      members.value.unshift(data.data)
+      assign.value.email = ''
+      assign.value.role = 'viewer'
+      addToast('User assigned successfully.', 'success')
+    } catch (e) {
+      const message = e?.response?.data?.message || 'Failed to assign user'
+      assignError.value = message
+      addToast(message, 'danger')
+    } finally {
+      assignLoading.value = false
+    }
+  }
+
+  async function updateRole(m) {
+    const originalRole = members.value.find(mem => mem.id === m.id)?.role
+    if (originalRole === m.role) return
+    try {
+      const { data } = await http.post('/commands', {
+        email: m.email,
+        company: unref(company),
+        role: m.role,
+      }, { headers: withIdempotency({ 'X-Action': 'company.assign' }) })
+      const index = members.value.findIndex(mem => mem.id === m.id)
+      if (index !== -1) members.value.splice(index, 1, data.data)
+      addToast('Role updated successfully.', 'success')
+    } catch (e) {
+      m.role = originalRole
+      addToast(e?.response?.data?.message || 'Failed to update role', 'danger')
+    }
+  }
+
+  async function unassign(m) {
+    if (!confirm(`Remove ${m.email} from ${unref(company)}?`)) return
+    try {
+      await http.post('/commands', {
+        email: m.email,
+        company: unref(company),
+      }, { headers: withIdempotency({ 'X-Action': 'company.unassign' }) })
+      members.value = members.value.filter(mem => mem.id !== m.id)
+      addToast('User removed successfully.', 'success')
+    } catch (e) {
+      addToast(e?.response?.data?.message || 'Failed to remove user', 'danger')
+    }
+  }
+
+  watch(q, () => { const t = setTimeout(loadMembers, 250); return () => clearTimeout(t) })
+
+  return {
+    members,
+    loading,
+    error,
+    q,
+    roleOptions,
+    assign,
+    assignLoading,
+    assignError,
+    loadMembers,
+    assignUser,
+    updateRole,
+    unassign,
+  }
+}


### PR DESCRIPTION
## Summary
- Extract company detail card into `CompanyOverview`
- Move member management UI into `CompanyMembersSection`
- Isolate invitation workflow via `CompanyInviteSection`
- Centralize member and invite HTTP logic in `useCompanyMembers` and `useCompanyInvites` composables

## Testing
- `npm run build` *(fails: Element is missing end tag in PalettePanel.vue)*
- `vendor/bin/phpunit` *(fails: Vite manifest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b93c53d83c8322b1e4b23bf667d19d