### PR TITLE
Clarify dev console config in app settings

### DIFF
--- a/app/config/app.php
+++ b/app/config/app.php
@@ -24,10 +24,11 @@ return [
     | running in. This may determine how you prefer to configure various
     | services the application utilizes. Set this in your ".env" file.
     |
+    | The "dev_console_enabled" option toggles the development console.
+    |
     */
 
     'env' => env('APP_ENV', 'production'),
-       // config/app.php
     'dev_console_enabled' => (bool) env('DEV_CONSOLE_ENABLED', false),
 
     /*


### PR DESCRIPTION
## Summary
- document `dev_console_enabled` option in app environment block
- remove stray `config/app.php` comment

## Testing
- `composer test` *(fails: connection to server at "127.0.0.1", port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b95c25f7888322883463813e415e03