### PR TITLE
Clear tenancy company session and expand membership tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#App Deployment Guide
+# App Deployment Guide
 
 ## 1. SME Modular Accounting — Deployment, Operations, and Expansion Guide (PostgreSQL)
 

--- a/app/app/Support/Tenancy.php
+++ b/app/app/Support/Tenancy.php
@@ -57,9 +57,10 @@ class Tenancy
         try {
             DB::select("select set_config('app.current_user_id', ?, true)", [$user->getKey()]);
             DB::select("select set_config('app.current_user_email', ?, true)", [strtolower($user->email)]);
-            if ($companyId) {
-                DB::select("select set_config('app.current_company_id', ?, true)", [$companyId]);
-            }
+            DB::select(
+                "select set_config('app.current_company_id', ?, true)",
+                [$companyId ?: '']
+            );
         } catch (\Throwable $e) {
             // noop for non-PgSQL
         }

--- a/app/tests/Unit/CompanyMembershipRepositoryTest.php
+++ b/app/tests/Unit/CompanyMembershipRepositoryTest.php
@@ -42,5 +42,29 @@ class CompanyMembershipRepositoryTest extends TestCase
             $c2->id,
         ], $memberships->pluck('id')->all());
     }
+
+    public function test_upsert_membership_inserts_and_updates(): void
+    {
+        $user = User::factory()->create();
+        $company = Company::factory()->create();
+
+        $repo = new CompanyMembershipRepository();
+
+        $repo->upsertMembership($company->id, $user->id, 'owner');
+
+        $this->assertDatabaseHas('auth.company_user', [
+            'company_id' => $company->id,
+            'user_id' => $user->id,
+            'role' => 'owner',
+        ]);
+
+        $repo->upsertMembership($company->id, $user->id, 'admin');
+
+        $this->assertDatabaseHas('auth.company_user', [
+            'company_id' => $company->id,
+            'user_id' => $user->id,
+            'role' => 'admin',
+        ]);
+    }
 }
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -100,7 +100,7 @@ LedgerFly is a hybrid accounting app designed for SMEs that merges the power and
 
 * "Zero-friction first time use"
 * Onboarding via CLI wizard or GUI tour
-* Realtime CLI/GU sync view
+* Realtime CLI/GUI sync view
 * Dashboard with widgets for pending invoices, due bills, bank balances
 
 ---


### PR DESCRIPTION
## Summary
- Fix README heading so title renders properly
- Correct CLI/GUI typo in product requirements document
- Clear stale session company ID in Tenancy::applyDbSessionSettings
- Add coverage for CompanyMembershipRepository::upsertMembership insert/update cases

## Testing
- `php artisan test` *(fails: connection to server at "127.0.0.1", port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b95e9fb808832294d92d4c8734d230