### PR TITLE
Inject CompanyLookupService into LookupService for membership filtering

### DIFF
--- a/app/app/Services/CompanyLookupService.php
+++ b/app/app/Services/CompanyLookupService.php
@@ -148,6 +148,23 @@ class CompanyLookupService
         });
     }
 
+    public function restrictCompaniesToUserIdOrEmail(Builder $query, ?string $userId, ?string $email): void
+    {
+        if (! $userId && ! $email) {
+            return;
+        }
+
+        if (! $userId && $email) {
+            $userId = DB::table('users')->where('email', $email)->value('id');
+            if (! $userId) {
+                $query->whereRaw('1 = 0');
+                return;
+            }
+        }
+
+        $this->restrictCompaniesToUser($query, $userId);
+    }
+
     public function upsertMember(string $companyId, string $userId, array $data): void
     {
         $now = $data['updated_at'] ?? now();

--- a/app/tests/Feature/LookupServiceTest.php
+++ b/app/tests/Feature/LookupServiceTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature;
 
 use App\Models\Company;
 use App\Models\User;
+use App\Services\CompanyLookupService;
 use App\Services\LookupService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
@@ -19,7 +20,7 @@ class LookupServiceTest extends TestCase
         $companyB = Company::factory()->create(['name' => 'Beta']);
         $user->companies()->attach($companyA->id, ['role' => 'member']);
 
-        $service = new LookupService();
+        $service = new LookupService(new CompanyLookupService());
         $results = $service->companies($user);
 
         $this->assertCount(1, $results);
@@ -32,7 +33,7 @@ class LookupServiceTest extends TestCase
         Company::factory()->create(['name' => 'Acme Co']);
         Company::factory()->create(['name' => 'Beta Co']);
 
-        $service = new LookupService();
+        $service = new LookupService(new CompanyLookupService());
         $results = $service->companies($super, 'Acme');
 
         $this->assertCount(1, $results);
@@ -46,7 +47,7 @@ class LookupServiceTest extends TestCase
         $company = Company::factory()->create(['name' => 'Gamma']);
         $member->companies()->attach($company->id, ['role' => 'member']);
 
-        $service = new LookupService();
+        $service = new LookupService(new CompanyLookupService());
         $results = $service->companies($super, '', 10, ['user_email' => $member->email]);
 
         $this->assertCount(1, $results);


### PR DESCRIPTION
## Summary
- Inject `CompanyLookupService` into `LookupService`
- Replace raw subqueries with service helpers for membership and admin user filters
- Update feature tests for dependency injection

## Testing
- `./vendor/bin/phpunit --testsuite Feature --filter LookupServiceTest` *(fails: SQLSTATE[08006] [7] connection to server at "127.0.0.1", port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b967405d588322b920e27e0c306e5f