### PR TITLE
Use CompanyLookupService for DevOps membership checks

### DIFF
--- a/app/app/Actions/DevOps/CompanyAssign.php
+++ b/app/app/Actions/DevOps/CompanyAssign.php
@@ -4,11 +4,16 @@ namespace App\Actions\DevOps;
 
 use App\Models\Company;
 use App\Models\User;
-use Illuminate\Support\Facades\Validator;
+use App\Services\CompanyLookupService;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Validator;
 
 class CompanyAssign
 {
+    public function __construct(private CompanyLookupService $lookup)
+    {
+    }
+
     public function handle(array $p, User $actor): array
     {
         $data = Validator::make($p, [
@@ -31,11 +36,10 @@ class CompanyAssign
         if (!$actor->isSuperAdmin()) {
             $active = session('current_company_id');
             abort_if($active !== $company->id, 403);
-            $isOwner = $actor->companies()
-                ->where('auth.company_user.company_id', $company->id)
-                ->wherePivot('role', 'owner')
-                ->exists();
-            abort_unless($isOwner, 403);
+            abort_unless(
+                $this->lookup->userHasRole($company->id, $actor->id, ['owner']),
+                403
+            );
         }
 
         DB::transaction(function () use ($data, $company) {


### PR DESCRIPTION
## Summary
- Inject CompanyLookupService into DevOps company assign/unassign actions
- Replace direct Eloquent owner queries with userHasRole checks

## Testing
- `composer test` *(fails: SQLSTATE[08006] connection to server at "127.0.0.1", port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b96745173883229e0e481376034a3c