### PR TITLE
Expose membership timestamps in lookup service

### DIFF
--- a/app/app/Services/CompanyLookupService.php
+++ b/app/app/Services/CompanyLookupService.php
@@ -120,7 +120,7 @@ class CompanyLookupService
             ->join('auth.companies as c', 'c.id', '=', 'cu.company_id')
             ->where('cu.user_id', $userId)
             ->orderBy('c.name')
-            ->get(['c.id','c.name','c.slug','cu.role']);
+            ->get(['c.id','c.name','c.slug','cu.role','cu.created_at','cu.updated_at']);
     }
 
     public function shareCompany(string $userId, string $otherUserId): bool

--- a/app/resources/js/types/index.d.ts
+++ b/app/resources/js/types/index.d.ts
@@ -20,6 +20,8 @@ export interface UserMembership {
   name: string;
   slug: string;
   role: string;
+  created_at: string;
+  updated_at: string;
 }
 
 // Represents a navigation link item


### PR DESCRIPTION
## Summary
- Include `created_at` and `updated_at` in user membership lookup
- Extend `UserMembership` TypeScript type with timestamp fields

## Testing
- `./vendor/bin/phpunit` *(fails: Unable to locate file in Vite manifest)*
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b967499ec8832288f4651118d3be90