### PR TITLE
feat: improve theme management

### DIFF
--- a/app/resources/css/app.css
+++ b/app/resources/css/app.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+    font-family: var(--app-font, 'Figtree', sans-serif);
+}

--- a/app/resources/js/Components/ThemeSwitcher.vue
+++ b/app/resources/js/Components/ThemeSwitcher.vue
@@ -1,48 +1,18 @@
 <script setup>
-import { ref, onMounted, watch, computed } from 'vue'
+import { computed } from 'vue';
+import { useTheme } from '../utils/theme';
 
-const theme = ref(localStorage.getItem('theme') || 'system')
-
-const prefersDarkMode = ref(window.matchMedia('(prefers-color-scheme: dark)'))
-
-const applyTheme = () => {
-    if (theme.value === 'dark' || (theme.value === 'system' && prefersDarkMode.value.matches)) {
-        document.documentElement.classList.add('dark')
-    } else {
-        document.documentElement.classList.remove('dark')
-    }
-}
-
-const cycleTheme = () => {
-    const themes = ['light', 'dark', 'system'];
-    const currentIndex = themes.indexOf(theme.value);
-    const nextTheme = themes[(currentIndex + 1) % themes.length];
-    theme.value = nextTheme;
-}
-
-watch(theme, (newTheme) => {
-    if (newTheme === 'system') {
-        localStorage.removeItem('theme')
-    } else {
-        localStorage.setItem('theme', newTheme)
-    }
-    applyTheme()
-})
-
-onMounted(() => {
-    applyTheme()
-    prefersDarkMode.value.addEventListener('change', applyTheme)
-})
+const { theme, font, cycleTheme, cycleFont } = useTheme();
 
 const currentIcon = computed(() => {
-    if (theme.value === 'light') return 'sun'
-    if (theme.value === 'dark') return 'moon'
-    return 'computer-desktop'
-})
+    if (theme.value === 'light') return 'sun';
+    if (theme.value === 'dark') return 'moon';
+    return 'computer-desktop';
+});
 </script>
 
 <template>
-    <div class="relative">
+    <div class="flex space-x-2">
         <button
             @click="cycleTheme"
             class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 dark:text-gray-500 hover:text-gray-500 dark:hover:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none focus:bg-gray-100 dark:focus:bg-gray-800 focus:text-gray-500 dark:focus:text-gray-400 transition duration-150 ease-in-out"
@@ -63,6 +33,13 @@ const currentIcon = computed(() => {
             <svg v-if="currentIcon === 'computer-desktop'" class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
             </svg>
+        </button>
+        <button
+            @click="cycleFont"
+            class="inline-flex items-center justify-center p-2 rounded-md text-gray-400 dark:text-gray-500 hover:text-gray-500 dark:hover:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800 focus:outline-none focus:bg-gray-100 dark:focus:bg-gray-800 focus:text-gray-500 dark:focus:text-gray-400 transition duration-150 ease-in-out"
+        >
+            <span class="sr-only">Switch font</span>
+            <span :class="{'font-serif': font === 'serif', 'font-mono': font === 'mono', 'font-sans': font === 'sans'}">A</span>
         </button>
     </div>
 </template>

--- a/app/resources/js/app.js
+++ b/app/resources/js/app.js
@@ -4,6 +4,10 @@ import { createInertiaApp } from '@inertiajs/vue3'
 import { createApp, h } from 'vue'
 import { ZiggyVue } from '../../vendor/tightenco/ziggy'
 import '../css/app.css';
+import { useTheme } from './utils/theme';
+
+// initialize theme handling on app startup
+useTheme();
 
 createInertiaApp({
   resolve: name => {

--- a/app/resources/js/utils/theme.js
+++ b/app/resources/js/utils/theme.js
@@ -1,0 +1,56 @@
+import { ref, watch } from 'vue';
+
+const theme = ref(localStorage.getItem('theme') || 'system');
+const font = ref(localStorage.getItem('font') || 'sans');
+
+const prefersDark = window.matchMedia('(prefers-color-scheme: dark)');
+
+const fonts = {
+    sans: 'Figtree, sans-serif',
+    serif: 'Georgia, serif',
+    mono: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+};
+
+function applyTheme() {
+    const isDark = theme.value === 'dark' || (theme.value === 'system' && prefersDark.matches);
+    document.documentElement.classList.toggle('dark', isDark);
+}
+
+function applyFont() {
+    document.documentElement.style.setProperty('--app-font', fonts[font.value]);
+}
+
+watch(theme, (val) => {
+    if (val === 'system') {
+        localStorage.removeItem('theme');
+    } else {
+        localStorage.setItem('theme', val);
+    }
+    applyTheme();
+});
+
+watch(font, (val) => {
+    localStorage.setItem('font', val);
+    applyFont();
+});
+
+prefersDark.addEventListener('change', applyTheme);
+
+applyTheme();
+applyFont();
+
+export function useTheme() {
+    const cycleTheme = () => {
+        const themes = ['light', 'dark', 'system'];
+        const next = themes[(themes.indexOf(theme.value) + 1) % themes.length];
+        theme.value = next;
+    };
+
+    const cycleFont = () => {
+        const options = Object.keys(fonts);
+        const next = options[(options.indexOf(font.value) + 1) % options.length];
+        font.value = next;
+    };
+
+    return { theme, font, cycleTheme, cycleFont };
+}

--- a/app/resources/views/app.blade.php
+++ b/app/resources/views/app.blade.php
@@ -18,14 +18,25 @@
 
         <script>
             // On page load or when changing themes, best to add inline in `head` to avoid FOUC
-            if (localStorage.getItem('theme') === 'dark' || (!('theme' in localStorage) && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+            const storedTheme = localStorage.getItem('theme');
+            const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            if (storedTheme === 'dark' || (!storedTheme && prefersDark)) {
                 document.documentElement.classList.add('dark');
             } else {
                 document.documentElement.classList.remove('dark');
             }
+            const fonts = {
+                sans: 'Figtree, sans-serif',
+                serif: 'Georgia, serif',
+                mono: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+            };
+            const storedFont = localStorage.getItem('font');
+            if (storedFont && fonts[storedFont]) {
+                document.documentElement.style.setProperty('--app-font', fonts[storedFont]);
+            }
         </script>
     </head>
-    <body class="font-sans antialiased">
+    <body class="antialiased">
         @inertia
     </body>
 </html>


### PR DESCRIPTION
## Summary
- centralize theme handling with utility for dark/light modes and font selection
- extend theme switcher and global scripts to leverage new theme system

## Testing
- `npm test` (fails: Missing script "test")
- `phpunit` (fails: command not found)
- `npm run build` (fails: Could not resolve '../../vendor/tightenco/ziggy')

------
https://chatgpt.com/codex/tasks/task_e_68b96d971c448322a39f16fba5eed92f