### PR TITLE
Cast session company ID before command execution

### DIFF
--- a/app/app/Http/Controllers/CommandController.php
+++ b/app/app/Http/Controllers/CommandController.php
@@ -16,6 +16,7 @@ class CommandController extends Controller
         $user   = $request->user();
         $params = $request->all();
         $companyId = $request->session()->get('current_company_id');
+        $companyId = $companyId !== null ? (int) $companyId : null;
 
         [$body, $status] = $executor->execute($action, $params, $user, $companyId, $key);
 


### PR DESCRIPTION
## Summary
- Cast `current_company_id` from session to `int|null` before executing commands

## Testing
- `composer test` *(fails: connection to server at "127.0.0.1", port 5432 failed: Connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b9803ee3f08322a92b2db9146121a4