### PR TITLE
Add command bus actions for invitation handling

### DIFF
--- a/app/app/Actions/Company/CompanyInvite.php
+++ b/app/app/Actions/Company/CompanyInvite.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Actions\Company;
+
+use App\Actions\Company\InviteUser;
+use App\Models\User;
+use Illuminate\Support\Facades\Validator;
+
+class CompanyInvite
+{
+    public function __construct(private InviteUser $inviter)
+    {
+    }
+
+    public function handle(array $p, User $actor): array
+    {
+        $data = Validator::make($p, [
+            'company' => 'required|string',
+            'email' => 'required|email',
+            'role' => 'required|in:owner,admin,accountant,viewer,member',
+            'expires_in_days' => 'nullable|integer|min:1',
+        ])->validate();
+
+        $inv = $this->inviter->handle($data['company'], $data, $actor);
+
+        return [
+            'message' => 'Invitation created',
+            'data' => [
+                'id' => $inv['id'],
+                'email' => $inv['email'],
+                'role' => $inv['role'],
+                'status' => $inv['status'],
+            ],
+        ];
+    }
+}

--- a/app/app/Actions/Invitation/InvitationRevoke.php
+++ b/app/app/Actions/Invitation/InvitationRevoke.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Actions\Invitation;
+
+use App\Models\CompanyInvitation;
+use App\Models\User;
+use App\Services\InvitationService;
+use Illuminate\Support\Facades\Validator;
+
+class InvitationRevoke
+{
+    public function __construct(private InvitationService $service)
+    {
+    }
+
+    public function handle(array $p, User $actor): array
+    {
+        $data = Validator::make($p, [
+            'id' => 'required|string',
+        ])->validate();
+
+        $inv = CompanyInvitation::findOrFail($data['id']);
+
+        $this->service->revoke($actor, $inv->id);
+
+        return [
+            'message' => 'Invitation revoked',
+            'data' => [
+                'id' => $inv->id,
+                'email' => $inv->invited_email,
+                'role' => $inv->role,
+                'status' => 'revoked',
+            ],
+        ];
+    }
+}

--- a/app/config/command-bus.php
+++ b/app/config/command-bus.php
@@ -7,5 +7,7 @@ return [
     'company.delete' => App\Actions\DevOps\CompanyDelete::class,
     'company.assign' => App\Actions\DevOps\CompanyAssign::class,
     'company.unassign' => App\Actions\DevOps\CompanyUnassign::class,
+    'company.invite' => App\Actions\Company\CompanyInvite::class,
+    'invitation.revoke' => App\Actions\Invitation\InvitationRevoke::class,
 ];
 


### PR DESCRIPTION
## Summary
- add CompanyInvite action for command bus invites
- add InvitationRevoke action for revoking invites
- register company.invite and invitation.revoke commands

## Testing
- `composer test` *(fails: SQLSTATE[08006] connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b9804bca388322aea820e7cfa04304