### PR TITLE
feat: add dev console toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -537,6 +537,7 @@ Additional routes and sample requests are available in the API documentation wit
 1. **Environment**
    - Copy `.env.example` to `.env`.
    - Configure database credentials and other environment variables.
+   - Set `DEV_CONSOLE_ENABLED=true` in `.env` to enable the development CLI when needed.
    - Install dependencies with `composer install`.
    - Generate the application key: `php artisan key:generate`.
 2. **Migrations**

--- a/app/README.md
+++ b/app/README.md
@@ -14,6 +14,7 @@ Haasib is a modular accounting and business management platform built on the Lar
    ```
 3. **Configure environment**
    Copy `.env.example` to `.env` and update database and service credentials.
+   Set `DEV_CONSOLE_ENABLED=true` to enable the development CLI when needed.
 4. **Generate application key**
    ```bash
    php artisan key:generate

--- a/app/config/app.php
+++ b/app/config/app.php
@@ -29,7 +29,7 @@ return [
     */
 
     'env' => env('APP_ENV', 'production'),
-    'dev_console_enabled' => (bool) env('DEV_CONSOLE_ENABLED', false),
+    'dev_console_enabled' => env('DEV_CONSOLE_ENABLED', false),
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- allow enabling a development console via `DEV_CONSOLE_ENABLED` config
- document `DEV_CONSOLE_ENABLED` in README for easier usage

## Testing
- `composer test` *(fails: connection to server at "127.0.0.1" refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b9805870e08322bd7854b2cb97b6a5