### PR TITLE
fix: unwrap palette state refs in command palette

### DIFF
--- a/app/resources/js/Components/CommandPalette.vue
+++ b/app/resources/js/Components/CommandPalette.vue
@@ -107,9 +107,9 @@ onUnmounted(() => {
     <DialogPortal>
       <DialogOverlay class="fixed inset-0 bg-black/70 backdrop-blur-sm" />
       <div class="fixed inset-x-0 bottom-0 flex items-end justify-center pb-2 sm:pb-4 px-2">
-        <DialogContent class="w-full max-w-5xl flex flex-col lg:flex-row gap-4" :class="[palette.showResults ? 'lg:max-w-5xl' : '', dockSize === 'full' ? 'h-[88vh]' : 'h-[56vh]']">
+        <DialogContent class="w-full max-w-5xl flex flex-col lg:flex-row gap-4" :class="[palette.showResults.value ? 'lg:max-w-5xl' : '', dockSize === 'full' ? 'h-[88vh]' : 'h-[56vh]']">
           <PalettePanel :palette="palette" :handle-keydown="handleKeydown" :is-expanded="isExpanded" />
-          <PaletteResults :results="palette.results" :show="palette.showResults" @close="palette.showResults = false" />
+          <PaletteResults :results="palette.results.value" :show="palette.showResults.value" @close="palette.showResults.value = false" />
         </DialogContent>
       </div>
     </DialogPortal>

--- a/app/resources/js/Components/PalettePanel.vue
+++ b/app/resources/js/Components/PalettePanel.vue
@@ -27,7 +27,7 @@ usePalettePanelWatch(
   <!-- Main Command Palette - Enhanced design -->
   <div class="flex-1 bg-gray-900/95 backdrop-blur-md border border-gray-700 rounded-t-xl shadow-2xl font-mono text-sm overflow-hidden" :class="isExpanded ? 'scale-100 opacity-100' : 'scale-105 opacity-0'" @keydown="(e) => { if (e.key === 'Escape') { e.preventDefault(); e.stopPropagation(); goBack() } }">
     <div class="flex flex-col h-full" @keydown="handleKeydown" ref="mainPanelEl" tabindex="-1">
-      <PaletteHeader :go-back="goBack" :go-home="palette.goHome" :status-text="palette.statusText" />
+      <PaletteHeader :go-back="goBack" :go-home="palette.goHome" :status-text="palette.statusText.value" />
       <PaletteCommandInput :palette="palette" />
       <PaletteSuggestions :palette="palette" :delete-confirm-input-el="deleteConfirmInputEl" />
     </div>


### PR DESCRIPTION
## Summary
- unwrap `showResults`, `results`, and `statusText` refs before passing to child components to satisfy prop type checks

## Testing
- `composer test` *(fails: SQLSTATE[08006] connection to server at "127.0.0.1", port 5432 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b9916745cc8322a56edb7cfcb2010a